### PR TITLE
tetrahedra, two step interpolation and gemm d3 rotation in linewidth

### DIFF
--- a/thermal2/PROGRAM_lw.f90
+++ b/thermal2/PROGRAM_lw.f90
@@ -12,576 +12,578 @@
 !
 !
 MODULE linewidth_program
-  USE timers
-  !
-  USE kinds,       ONLY : DP
-  !USE mpi_thermal,      ONLY : ionode
+   USE timers
+   !
+   USE kinds,       ONLY : DP
+   !USE mpi_thermal,      ONLY : ionode
 #include "mpi_thermal.h"
-  !
-  CONTAINS
-  SUBROUTINE LW_QBZ_LINE(input, qpath, S, fc2, fc3)
-    USE fc2_interpolate,    ONLY : fftinterp_mat2, mat2_diag, freq_phq_path
-    USE linewidth,          ONLY : linewidth_q, selfnrg_q, spectre_q
-    USE constants,          ONLY : RY_TO_CMM1
-    USE q_grids,            ONLY : q_grid, setup_grid
-    USE mc_grids,           ONLY : setup_poptimized_grid
-    USE more_constants,     ONLY : write_conf
-    USE fc3_interpolate,    ONLY : forceconst3
-    USE isotopes_linewidth, ONLY : isotopic_linewidth_q
-    USE casimir_linewidth,  ONLY : casimir_linewidth_q
-    USE input_fc,           ONLY : forceconst2_grid, ph_system_info
-    USE code_input,         ONLY : code_input_type
-    USE overlap,            ONLY : order_type
-    IMPLICIT NONE
-    !
-    TYPE(code_input_type),INTENT(in)  :: input
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: qpath
-    !
-    TYPE(order_type) :: order
-    COMPLEX(DP) :: D(S%nat3, S%nat3)
-    REAL(DP) :: w2(S%nat3), xq_ref(3)
-    INTEGER :: iq, it, i
-    TYPE(q_grid) :: grid
-    COMPLEX(DP):: ls(S%nat3,input%nconf), lsx(S%nat3)
-    REAL(DP)   :: lw(S%nat3,input%nconf), lw_isot(S%nat3,input%nconf)
-    REAL(DP)   :: lw_casimir(S%nat3)
-    REAL(DP)   :: sigma_ry(input%nconf)
-    CHARACTER(len=32) :: f1, f2
-    CHARACTER(len=256) :: filename
-    CHARACTER(len=6) :: pos 
-    !
-    IF(.not. input%optimize_grid)THEN
-      ioWRITE(*,*) "--> Setting up inner grid"
-      CALL setup_grid(input%grid_type, S%bg, input%nk(1), input%nk(2), input%nk(3), &
-                      grid, scatter=.true., xq0=input%xk0, quiet=.false.)
-    ENDIF
-    !
-    IF(ionode)THEN
-      IF(input%skip_q>0) THEN; pos="append"; ELSE; pos = "asis"; ENDIF
-      DO it = 1,input%nconf
-        filename=TRIM(input%outdir)//"/"//&
-                TRIM(input%prefix)//"_T"//TRIM(write_conf(it,input%nconf,input%T))//&
-                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out"
-        OPEN(unit=1000+it, file=filename, position=pos)
-        IF (TRIM(input%mode) == "full") THEN
-          ioWRITE(1000+it, *) "# calculation of linewidth (gamma_n) [and lineshift (delta_n)]"
-        ELSE
-          ioWRITE(1000+it, *) "# calculation of linewidth (gamma_n)"
-        ENDIF
-        ioWRITE(1000+it, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, &
-                         "     T=",input%T(it), "    sigma=", input%sigma(it)
-        ioFLUSH(1000+it)
-      ENDDO
-      ! Prepare formats to write out data
-      ioWRITE(f1,'(i6,a)') S%nat3, "f12.6,6x,"
-      ioWRITE(f2,'(i6,a)') S%nat3, "ES27.15E3,6x,"
-    ENDIF
-    !
-    ! Gaussian: exp(x^2/(2s^2)) => FWHM = 2sqrt(2log(2)) s
-    ! Wrong Gaussian exp(x^2/c^2) => FWHM = 2 sqrt(log(2)) c
-    ! Lorentzian: (g/2)/(x^2 + (g/2)^2) => FWHM = g
-    ! Wrong Lorentzian: d/(x^2+d^2) => FWHM = 2d
-    !  => 2d = 2 sqrt(log(2) c
-    !      d = sqrt(log(2)) c
-    !      d = 0.83255 c
-    ! IMHO: you need to use a sigma that is 0.6 (=0.5/0.83255) times smaller when using
-    ! linewidth_q than when using selfnrg_q in order to get the same values
-    ! THIS FACTOR IS NOW INCLUDED DIRECTLY IN SUM_LINEWIDTH_MODES!
-    sigma_ry = input%sigma/RY_TO_CMM1
-    !
-    ioWRITE(*,'(2x,a,i6,a)') "Going to compute", qpath%nq, " points (1)"
-    !
-    IF(input%sort_freq=="reference") CALL order%set_xq_ref(qpath%nq, qpath%xq, input%xq_ref)
-    !
-    DO iq = input%skip_q +1,qpath%nq
+   !
+CONTAINS
+   SUBROUTINE LW_QBZ_LINE(input, qpath, S, fc2, fc3)
+      USE fc2_interpolate,    ONLY : fftinterp_mat2, mat2_diag, freq_phq_path
+      USE linewidth,          ONLY : linewidth_q, selfnrg_q, spectre_q, check_negative_lw
+      USE constants,          ONLY : RY_TO_CMM1
+      USE q_grids,            ONLY : q_grid, setup_grid
+      USE mc_grids,           ONLY : setup_poptimized_grid
+      USE more_constants,     ONLY : write_conf
+      USE fc3_interpolate,    ONLY : forceconst3
+      USE isotopes_linewidth, ONLY : isotopic_linewidth_q
+      USE casimir_linewidth,  ONLY : casimir_linewidth_q
+      USE input_fc,           ONLY : forceconst2_grid, ph_system_info
+      USE code_input,         ONLY : code_input_type
+      USE overlap,            ONLY : order_type
+      IMPLICIT NONE
       !
-      CALL print_percent_wall(10._dp, 300._dp, iq, qpath%nq, (iq==1))
-      IF(input%optimize_grid)THEN
-        CALL grid%destroy()
-        CALL setup_poptimized_grid(input, S, fc2, grid, qpath%xq(:,iq), &
-                                  input%optimize_grid_thr, scatter=.true., fc3=fc3)
+      TYPE(code_input_type),INTENT(in)  :: input
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in)     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: qpath
+      !
+      TYPE(order_type) :: order
+      COMPLEX(DP) :: D(S%nat3, S%nat3)
+      REAL(DP) :: w2(S%nat3), xq_ref(3)
+      INTEGER :: iq, it, i
+      TYPE(q_grid) :: grid
+      COMPLEX(DP):: ls(S%nat3,input%nconf), lsx(S%nat3)
+      REAL(DP)   :: lw(S%nat3,input%nconf), lw_isot(S%nat3,input%nconf)
+      REAL(DP)   :: lw_casimir(S%nat3)
+      REAL(DP)   :: sigma_ry(input%nconf)
+      CHARACTER(len=32) :: f1, f2
+      CHARACTER(len=256) :: filename
+      CHARACTER(len=6) :: pos
+      !
+      IF(.not. input%optimize_grid)THEN
+         ioWRITE(*,*) "--> Setting up inner grid"
+         CALL setup_grid(input%grid_type, S%bg, input%nk(1), input%nk(2), input%nk(3), &
+            grid, scatter=.true., xq0=input%xk0, quiet=.false.)
       ENDIF
       !
-      CALL freq_phq_path(qpath%nq, iq, qpath%xq, S, fc2, w2, D)
-      !
-      ! If necessary, compute the ordering of the bands to assure modes continuity;
-      ! on first call, it just returns the trivial 1...3*nat order
-      !IF(input%sort_freq=="overlap" .or. iq==1) CALL order%set(S%nat3, w2, D)
-      IF(input%sort_freq=="overlap" .or. iq==input%skip_q +1) THEN
-          CALL order%set_path(S%nat3, w2, D, iq, qpath%nq, qpath%w, qpath%xq)
-      ELSEIF(input%sort_freq=="reference")THEN
-        CALL order%set_ref(S%nat3, qpath%xq(:,iq), S, fc2)
+      IF(ionode)THEN
+         IF(input%skip_q>0) THEN; pos="append"; ELSE; pos = "asis"; ENDIF
+         DO it = 1,input%nconf
+            filename=TRIM(input%outdir)//"/"//&
+               TRIM(input%prefix)//"_T"//TRIM(write_conf(it,input%nconf,input%T))//&
+               "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out"
+            OPEN(unit=1000+it, file=filename, position=pos)
+            IF (TRIM(input%mode) == "full") THEN
+               ioWRITE(1000+it, *) "# calculation of linewidth (gamma_n) [and lineshift (delta_n)]"
+            ELSE
+               ioWRITE(1000+it, *) "# calculation of linewidth (gamma_n)"
+            ENDIF
+            ioWRITE(1000+it, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, &
+               "     T=",input%T(it), "    sigma=", input%sigma(it)
+            ioFLUSH(1000+it)
+         ENDDO
+         ! Prepare formats to write out data
+         ioWRITE(f1,'(i6,a)') S%nat3, "f12.6,6x,"
+         ioWRITE(f2,'(i6,a)') S%nat3, "ES27.15E3,6x,"
       ENDIF
       !
-      ! Pre-compute isotopic linewidth
-      IF(input%isotopic_disorder)THEN
-          timer_CALL t_lwisot%start()
-        lw_isot = isotopic_linewidth_q(qpath%xq(:,iq), input%nconf, input%T,&
-                                        sigma_ry, S, grid, fc2, w2, D)
-          timer_CALL t_lwisot%stop()
-      ELSE
-        lw_isot = 0._dp
-      ENDIF
+      ! Gaussian: exp(x^2/(2s^2)) => FWHM = 2sqrt(2log(2)) s
+      ! Wrong Gaussian exp(x^2/c^2) => FWHM = 2 sqrt(log(2)) c
+      ! Lorentzian: (g/2)/(x^2 + (g/2)^2) => FWHM = g
+      ! Wrong Lorentzian: d/(x^2+d^2) => FWHM = 2d
+      !  => 2d = 2 sqrt(log(2) c
+      !      d = sqrt(log(2)) c
+      !      d = 0.83255 c
+      ! IMHO: you need to use a sigma that is 0.6 (=0.5/0.83255) times smaller when using
+      ! linewidth_q than when using selfnrg_q in order to get the same values
+      ! THIS FACTOR IS NOW INCLUDED DIRECTLY IN SUM_LINEWIDTH_MODES!
+      sigma_ry = input%sigma/RY_TO_CMM1
       !
-      ! Pre-compute Casimir finite sample size linewidth
-      IF(input%casimir_scattering)THEN
-          timer_CALL t_lwcasi%start()
-        lw_casimir = casimir_linewidth_q(qpath%xq(:,iq), input%sample_length, &
-                                      input%sample_dir, S, fc2)
-        timer_CALL t_lwcasi%stop()
-      ELSE
-        lw_casimir = 0._dp
-      ENDIF
+      ioWRITE(*,'(2x,a,i6,a)') "Going to compute", qpath%nq, " points (1)"
       !
-      MODE_SELECTION : &
-      IF (TRIM(input%mode) == "full") THEN
-          
-          timer_CALL t_lwphph%start()
-        ls = selfnrg_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
-                        S, grid, fc2, fc3, w2, D)
-          timer_CALL t_lwphph%stop()
-        !
-        DO it = 1,input%nconf
-          ! Add isotopes and Casimir to the imaginary part of ls
-          lsx = ls(:,it) - CMPLX(0._dp, lw_isot(:,it)+lw_casimir(:),kind=DP)
-          !
-          IF(TRIM(input%sort_freq)=="shifted") THEN
-            CALL resort_w_ls(S%nat3, w2, lsx)
-          ELSE
-            lsx = lsx + w2
-          ENDIF
-  
-          IF(qpath%w(iq)==0._dp .and. iq>1 .and. ionode) WRITE(1000+it, *)
-          ioWRITE(1000+it, '(i4,f12.6,2x,3f12.6,2x,'//f1//f2//f2//f2//f2//'x)') &
-                iq,qpath%w(iq),qpath%xq(:,iq), w2(order%idx(:))*RY_TO_CMM1, &
-                -DIMAG(lsx(order%idx(:)))*RY_TO_CMM1, &
+      IF(input%sort_freq=="reference") CALL order%set_xq_ref(qpath%nq, qpath%xq, input%xq_ref)
+      !
+      DO iq = input%skip_q +1,qpath%nq
+         !
+         CALL print_percent_wall(10._dp, 300._dp, iq, qpath%nq, (iq==1))
+         IF(input%optimize_grid)THEN
+            CALL grid%destroy()
+            CALL setup_poptimized_grid(input, S, fc2, grid, qpath%xq(:,iq), &
+               input%optimize_grid_thr, scatter=.true., fc3=fc3)
+         ENDIF
+         !
+         CALL freq_phq_path(qpath%nq, iq, qpath%xq, S, fc2, w2, D)
+         !
+         ! If necessary, compute the ordering of the bands to assure modes continuity;
+         ! on first call, it just returns the trivial 1...3*nat order
+         !IF(input%sort_freq=="overlap" .or. iq==1) CALL order%set(S%nat3, w2, D)
+         IF(input%sort_freq=="overlap" .or. iq==input%skip_q +1) THEN
+            CALL order%set_path(S%nat3, w2, D, iq, qpath%nq, qpath%w, qpath%xq)
+         ELSEIF(input%sort_freq=="reference")THEN
+            CALL order%set_ref(S%nat3, qpath%xq(:,iq), S, fc2)
+         ENDIF
+         !
+         ! Pre-compute isotopic linewidth
+         IF(input%isotopic_disorder)THEN
+            timer_CALL t_lwisot%start()
+            lw_isot = isotopic_linewidth_q(qpath%xq(:,iq), input%nconf, input%T,&
+               sigma_ry, S, grid, fc2, w2, D)
+            timer_CALL t_lwisot%stop()
+         ELSE
+            lw_isot = 0._dp
+         ENDIF
+         !
+         ! Pre-compute Casimir finite sample size linewidth
+         IF(input%casimir_scattering)THEN
+            timer_CALL t_lwcasi%start()
+            lw_casimir = casimir_linewidth_q(qpath%xq(:,iq), input%sample_length, &
+               input%sample_dir, S, fc2)
+            timer_CALL t_lwcasi%stop()
+         ELSE
+            lw_casimir = 0._dp
+         ENDIF
+         !
+         MODE_SELECTION : &
+            IF (TRIM(input%mode) == "full") THEN
+
+            timer_CALL t_lwphph%start()
+            ls = selfnrg_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
+               S, grid, fc2, fc3, w2, D)
+            timer_CALL t_lwphph%stop()
+            !
+            DO it = 1,input%nconf
+               ! Add isotopes and Casimir to the imaginary part of ls
+               lsx = ls(:,it) - CMPLX(0._dp, lw_isot(:,it)+lw_casimir(:),kind=DP)
+               !
+               IF(TRIM(input%sort_freq)=="shifted") THEN
+                  CALL resort_w_ls(S%nat3, w2, lsx)
+               ELSE
+                  lsx = lsx + w2
+               ENDIF
+
+               IF(qpath%w(iq)==0._dp .and. iq>1 .and. ionode) WRITE(1000+it, *)
+               ioWRITE(1000+it, '(i4,f12.6,2x,3f12.6,2x,'//f1//f2//f2//f2//f2//'x)') &
+                  iq,qpath%w(iq),qpath%xq(:,iq), w2(order%idx(:))*RY_TO_CMM1, &
+                  -DIMAG(lsx(order%idx(:)))*RY_TO_CMM1, &
                   DBLE(lsx(order%idx(:)))*RY_TO_CMM1, &
                   lw_isot(order%idx(:),it)*RY_TO_CMM1, &
                   lw_casimir(order%idx(:))*RY_TO_CMM1
-          
-          ioFLUSH(1000+it)
-        ENDDO
+
+               ioFLUSH(1000+it)
+            ENDDO
+            !
+            ! MODE_SELECTION !
+         ELSE IF (TRIM(input%mode) == "real" .or. TRIM(input%mode) == "imag") THEN
+            !
+            timer_CALL t_lwphph%start()
+            lw = linewidth_q(qpath%xq(:,iq), S, fc2, fc3, grid, input)
+            ! CALL check_negative_lw(lw, qpath%xq(:,iq), S%nat3, input%nconf, "lw:phph")
+            timer_CALL t_lwphph%stop()
+            !
+            DO it = 1,input%nconf
+               !
+               ! Add isotopic and casimir linewidths
+               lw(:,it) = lw(:,it) + lw_isot(:,it) + lw_casimir
+               !
+               ioWRITE(1000+it, '(i4,f12.6,2x,3f12.6,2x,'//f1//f2//f2//f2//'x)') &
+                  iq,qpath%w(iq),qpath%xq(:,iq), &
+                  w2(order%idx(:))*RY_TO_CMM1, lw(order%idx(:),it)*RY_TO_CMM1, &
+                  lw_isot(order%idx(:),it)*RY_TO_CMM1, lw_casimir(order%idx(:))*RY_TO_CMM1
+               ioFLUSH(1000+it)
+            ENDDO
+            !
+         ELSE
+            !
+            CALL errore('LW_QBZ_LINE', 'wrong mode (imag or full)', 1)
+            !
+         ENDIF MODE_SELECTION
+         !
+      ENDDO
       !
-      ! MODE_SELECTION !
-      ELSE IF (TRIM(input%mode) == "real" .or. TRIM(input%mode) == "imag") THEN
       !
-          timer_CALL t_lwphph%start()
-        lw = linewidth_q(qpath%xq(:,iq), input%nconf, input%T,  sigma_ry, &
-                        S, grid, fc2, fc3, w2, D)
-          timer_CALL t_lwphph%stop()
-        !
-        DO it = 1,input%nconf
-          !
-          ! Add isotopic and casimir linewidths
-          lw(:,it) = lw(:,it) + lw_isot(:,it) + lw_casimir
-          !
-          ioWRITE(1000+it, '(i4,f12.6,2x,3f12.6,2x,'//f1//f2//f2//f2//'x)') &
-                iq,qpath%w(iq),qpath%xq(:,iq), &
-                w2(order%idx(:))*RY_TO_CMM1, lw(order%idx(:),it)*RY_TO_CMM1, &
-                lw_isot(order%idx(:),it)*RY_TO_CMM1, lw_casimir(order%idx(:))*RY_TO_CMM1
-          ioFLUSH(1000+it)
-        ENDDO
+      IF(ionode)THEN
+         DO it = 1,input%nconf
+            CLOSE(unit=1000+it)
+         ENDDO
+      ENDIF
       !
-      ELSE
       !
-        CALL errore('LW_QBZ_LINE', 'wrong mode (imag or full)', 1)
-      !
-      ENDIF MODE_SELECTION
-      !
-    ENDDO
-    !
-    !
-    IF(ionode)THEN
-    DO it = 1,input%nconf
-      CLOSE(unit=1000+it)
-    ENDDO
-    ENDIF
-    !
+   END SUBROUTINE LW_QBZ_LINE
    !
-  END SUBROUTINE LW_QBZ_LINE
-  !
-  ! Sort w and ls so that w+real(ls) is in increasing order
-  ! On output, return ls+w correctly sorted, leave w unchanged
-  ! Note that the imaginary part of ls (the linewidth) will also
-  ! be sorted in the order w+real(ls) during the process
-  SUBROUTINE resort_w_ls(nat3, w, ls)
-    IMPLICIT NONE
-    INTEGER,INTENT(in) :: nat3
-    REAL(DP),INTENT(in) :: w(nat3)
-    COMPLEX(DP),INTENT(inout):: ls(nat3)
-    !
-    REAL(DP)   :: wx(nat3)
-    COMPLEX(DP):: lsx(nat3)
-    REAL(DP)   :: tot(nat3), maxx, minx
-    INTEGER    :: i,j
-    ! Use stupid O(n^2) sort as quicksort with two lists would be boring to implement
-    tot = w + DBLE(ls)
-    maxx = MAXVAL(tot)+1._dp
-    DO i = 1, nat3
-      minx = MINVAL(tot)
-      j_LOOP : DO j = 1,nat3
-        IF(tot(j)==minx)THEN
-        !ioWRITE(*,'(a,2i3,4f12.6)') "min", i, j, minx, wx(i), DBLE(lsx(i)), tot(j)
-         wx(i)  = w(j)
-         lsx(i) = ls(j)
-         tot(j) = maxx
-         EXIT j_LOOP
-        ENDIF
-      ENDDO j_LOOP
-    ENDDO
-    !w  = wx
-    ls = lsx+wx
-  END SUBROUTINE
-  !
-  SUBROUTINE SPECTR_QBZ_LINE(input, qpath, S, fc2, fc3)
-    USE fc2_interpolate,     ONLY : fftinterp_mat2, mat2_diag, freq_phq_path
-    USE linewidth,      ONLY : spectre_q, simple_spectre_q, add_exp_t_factor, &
-                               tepsilon_q, selfnrg_omega_q, ir_reflectivity_q, spectre2_q
-    USE constants,      ONLY : RY_TO_CMM1
-    USE q_grids,        ONLY : q_grid, setup_grid
-    USE more_constants, ONLY : write_conf
-    USE input_fc,       ONLY : forceconst2_grid, ph_system_info
-    USE fc3_interpolate,ONLY : forceconst3
-    USE code_input,     ONLY : code_input_type
-    !USE nanoclock,      ONLY : print_percent_wall
-    IMPLICIT NONE
-    !
-    TYPE(code_input_type),INTENT(in)     :: input
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(inout)  :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: qpath
-    !
-    INTEGER :: iq, it, ie, newfile
-    TYPE(q_grid) :: grid
-    COMPLEX(DP):: ls(S%nat3,input%nconf)
-    REAL(DP)   :: sigma_ry(input%nconf)
-    !
-    REAL(DP),ALLOCATABLE :: ener(:), spectralf(:,:,:)
-    COMPLEX(DP),ALLOCATABLE :: caux(:,:,:)
-    !
-    COMPLEX(DP) :: D(S%nat3, S%nat3)
-    REAL(DP) :: w2(S%nat3)
-    CHARACTER(len=6), EXTERNAL :: int_to_char
-    CHARACTER(len=6) :: pos
-    REAL(DP) :: UNIT_CONVERSION
-    !
-    ioWRITE(*,*) "--> Setting up inner grid"
-    CALL setup_grid(input%grid_type, S%bg, input%nk(1), input%nk(2), input%nk(3), grid, scatter=.true., xq0=input%xk0)
-    !CALL grid%scatter()
-    !
-    ALLOCATE(ener(input%ne))
-    FORALL(ie = 1:input%ne) ener(ie) = (ie-1)*input%de+input%e0
-    ener = ener/RY_TO_CMM1
-    sigma_ry = input%sigma/RY_TO_CMM1
-    !
-    IF(ionode)THEN
-      IF(input%skip_q>0) THEN; pos="append"; ELSE; pos = "asis"; ENDIF
-      newfile=0
-      DO it = 1,input%nconf
-        OPEN(unit=1000+it, position=pos, &
+   ! Sort w and ls so that w+real(ls) is in increasing order
+   ! On output, return ls+w correctly sorted, leave w unchanged
+   ! Note that the imaginary part of ls (the linewidth) will also
+   ! be sorted in the order w+real(ls) during the process
+   SUBROUTINE resort_w_ls(nat3, w, ls)
+      IMPLICIT NONE
+      INTEGER,INTENT(in) :: nat3
+      REAL(DP),INTENT(in) :: w(nat3)
+      COMPLEX(DP),INTENT(inout):: ls(nat3)
+      !
+      REAL(DP)   :: wx(nat3)
+      COMPLEX(DP):: lsx(nat3)
+      REAL(DP)   :: tot(nat3), maxx, minx
+      INTEGER    :: i,j
+      ! Use stupid O(n^2) sort as quicksort with two lists would be boring to implement
+      tot = w + DBLE(ls)
+      maxx = MAXVAL(tot)+1._dp
+      DO i = 1, nat3
+         minx = MINVAL(tot)
+         j_LOOP : DO j = 1,nat3
+            IF(tot(j)==minx)THEN
+               !ioWRITE(*,'(a,2i3,4f12.6)') "min", i, j, minx, wx(i), DBLE(lsx(i)), tot(j)
+               wx(i)  = w(j)
+               lsx(i) = ls(j)
+               tot(j) = maxx
+               EXIT j_LOOP
+            ENDIF
+         ENDDO j_LOOP
+      ENDDO
+      !w  = wx
+      ls = lsx+wx
+   END SUBROUTINE
+   !
+   SUBROUTINE SPECTR_QBZ_LINE(input, qpath, S, fc2, fc3)
+      USE fc2_interpolate,     ONLY : fftinterp_mat2, mat2_diag, freq_phq_path
+      USE linewidth,      ONLY : spectre_q, simple_spectre_q, add_exp_t_factor, &
+         tepsilon_q, selfnrg_omega_q, ir_reflectivity_q, spectre2_q
+      USE constants,      ONLY : RY_TO_CMM1
+      USE q_grids,        ONLY : q_grid, setup_grid
+      USE more_constants, ONLY : write_conf
+      USE input_fc,       ONLY : forceconst2_grid, ph_system_info
+      USE fc3_interpolate,ONLY : forceconst3
+      USE code_input,     ONLY : code_input_type
+      !USE nanoclock,      ONLY : print_percent_wall
+      IMPLICIT NONE
+      !
+      TYPE(code_input_type),INTENT(in)     :: input
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(inout)  :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: qpath
+      !
+      INTEGER :: iq, it, ie, newfile
+      TYPE(q_grid) :: grid
+      COMPLEX(DP):: ls(S%nat3,input%nconf)
+      REAL(DP)   :: sigma_ry(input%nconf)
+      !
+      REAL(DP),ALLOCATABLE :: ener(:), spectralf(:,:,:)
+      COMPLEX(DP),ALLOCATABLE :: caux(:,:,:)
+      !
+      COMPLEX(DP) :: D(S%nat3, S%nat3)
+      REAL(DP) :: w2(S%nat3)
+      CHARACTER(len=6), EXTERNAL :: int_to_char
+      CHARACTER(len=6) :: pos
+      REAL(DP) :: UNIT_CONVERSION
+      !
+      ioWRITE(*,*) "--> Setting up inner grid"
+      CALL setup_grid(input%grid_type, S%bg, input%nk(1), input%nk(2), input%nk(3), grid, scatter=.true., xq0=input%xk0)
+      !CALL grid%scatter()
+      !
+      ALLOCATE(ener(input%ne))
+      FORALL(ie = 1:input%ne) ener(ie) = (ie-1)*input%de+input%e0
+      ener = ener/RY_TO_CMM1
+      sigma_ry = input%sigma/RY_TO_CMM1
+      !
+      IF(ionode)THEN
+         IF(input%skip_q>0) THEN; pos="append"; ELSE; pos = "asis"; ENDIF
+         newfile=0
+         DO it = 1,input%nconf
+            OPEN(unit=1000+it, position=pos, &
+               file=TRIM(input%outdir)//"/"//TRIM(input%prefix)//&
+               "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
+               "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
+            ioWRITE(1000+it, *) "# spectral function mode: ", input%mode
+            ioWRITE(1000+it, '(a,i6,a,f6.1,a,100f6.1)') "#", it, "T=",input%T(it), "sigma=", input%sigma(it)
+            ioWRITE(1000+it, *) "#   q-path     energy (cm^-1)         total      band1      band2    ....     "
+            ioFLUSH(1000+it)
+         ENDDO
+      ENDIF
+      !
+      ioWRITE(*,'(2x,a,i6,a)') "Going to compute", qpath%nq, " points (2)"
+
+      DO iq = input%skip_q +1,qpath%nq
+         !CALL print_percent_wall(10._dp, 300._dp, iq, qpath%nq, (iq==1))
+         !
+         CALL freq_phq_path(qpath%nq, iq, qpath%xq, S, fc2, w2, D)
+         ioWRITE(*,'(i6,3f12.6,5x,6f12.6,100(/,47x,6f12.6))') iq, qpath%xq(:,iq), w2*RY_TO_CMM1
+         !
+         DO it = 1,input%nconf
+            IF(qpath%w(iq)==0._dp .and. iq>1 .and. ionode) THEN
+               CLOSE(1000+it)
+               newfile = newfile+1
+               OPEN(unit=1000+it, position=pos, &
                   file=TRIM(input%outdir)//"/"//TRIM(input%prefix)//&
-                       "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
-                       "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
-        ioWRITE(1000+it, *) "# spectral function mode: ", input%mode
-        ioWRITE(1000+it, '(a,i6,a,f6.1,a,100f6.1)') "#", it, "T=",input%T(it), "sigma=", input%sigma(it)
-        ioWRITE(1000+it, *) "#   q-path     energy (cm^-1)         total      band1      band2    ....     "
-        ioFLUSH(1000+it)
+                  "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
+                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//&
+                  "_p"//TRIM(int_to_char(newfile))//".out")
+            ENDIF
+            ioWRITE(1000+it, *)
+            ioWRITE(1000+it, '(a,i6,3f15.8,5x,100(/,"#",6f12.6))') "#  xq",  iq, qpath%xq(:,iq), w2*RY_TO_CMM1
+         ENDDO
+         !
+         IF (TRIM(input%calculation) == "spf") THEN
+            ALLOCATE(spectralf(input%ne,S%nat3,input%nconf))
+            IF (TRIM(input%mode) == "full") THEN
+               UNIT_CONVERSION = 1/RY_TO_CMM1
+               spectralf = spectre_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
+                  S, grid, fc2, fc3, input%ne, ener, w2, D, shift=.true.)
+            ELSE IF (TRIM(input%mode) == "full2") THEN
+               UNIT_CONVERSION = 1/RY_TO_CMM1
+               spectralf = spectre2_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
+                  S, grid, fc2, fc3, input%ne, ener, w2, D)
+            ELSE IF (TRIM(input%mode) == "imag") THEN
+               UNIT_CONVERSION = 1/RY_TO_CMM1
+               spectralf = spectre_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
+                  S, grid, fc2, fc3, input%ne, ener, w2, D, shift=.false.)
+            ELSE IF (TRIM(input%mode) == "simple" .or. TRIM(input%mode) == "isimple") THEN
+               UNIT_CONVERSION = 1/RY_TO_CMM1
+               spectralf = simple_spectre_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
+                  S, grid, fc2, fc3, input%ne, ener, w2, D, &
+                  shift=(TRIM(input%mode) == "simple"), input=input)
+            ELSE IF (TRIM(input%mode) == "refl") THEN
+               UNIT_CONVERSION = 1._dp
+               IF(ANY(qpath%xq(:,iq)/=0._dp).and.ionode) &
+                  WRITE(stdout,*) "WARNING! tilde epsilon out of Gamma makes no sense"
+               spectralf = ir_reflectivity_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
+                  S, grid, fc2, fc3, input%ne, ener, w2, D)
+            ELSE
+               CALL errore("SPECTR_QBZ_LINE", 'unknown mode "'//TRIM(input%mode)//'"', 1)
+            ENDIF
+            IF(input%exp_t_factor) CALL add_exp_t_factor(input%nconf, input%T, &
+               input%ne, S%nat3, ener, spectralf)
+            !
+            DO it = 1,input%nconf
+               DO ie = 1,input%ne
+                  ioWRITE(1000+it, '(2f14.8,100e14.6)') &
+                     qpath%w(iq), ener(ie)*RY_TO_CMM1, &
+                     SUM(spectralf(ie,:,it))*UNIT_CONVERSION, &
+                     spectralf(ie,:,it)*UNIT_CONVERSION
+                  ioFLUSH(1000+it)
+               ENDDO
+            ENDDO
+            DEALLOCATE(spectralf)
+         ELSE
+            ALLOCATE(caux(input%ne,S%nat3,input%nconf))
+            IF (TRIM(input%calculation) == "eps" .or. &
+               TRIM(input%calculation) == "refl"  ) THEN
+               UNIT_CONVERSION = 1._dp
+               IF(ANY(qpath%xq(:,iq)/=0._dp).and.ionode) WRITE(stdout,*) "WARNING! tilde epsilon out of Gamma makes no sense"
+               caux = tepsilon_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
+                  S, grid, fc2, fc3, input%ne, ener, w2, D)
+               IF(TRIM(input%calculation) == "refl") THEN
+                  caux = (SQRT(caux)-1)/(SQRT(caux)+1)
+                  caux = caux*CONJG(caux)
+               ENDIF
+            ELSE IF (TRIM(input%calculation) == "selfnrg") THEN
+               UNIT_CONVERSION = RY_TO_CMM1
+               caux = selfnrg_omega_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
+                  S, grid, fc2, fc3, input%ne, ener, w2, D)
+            ENDIF
+            !
+            DO it = 1,input%nconf
+               DO ie = 1,input%ne
+                  ioWRITE(1000+it, '(2f14.8,100(2e14.6,3x))') &
+                     qpath%w(iq), ener(ie)*RY_TO_CMM1, &
+                     SUM(caux(ie,:,it))*UNIT_CONVERSION, &
+                     caux(ie,:,it)*UNIT_CONVERSION
+                  ioFLUSH(1000+it)
+               ENDDO
+            ENDDO
+            !
+            DEALLOCATE(caux)
+         ENDIF
+         !
       ENDDO
-    ENDIF
-    !
-    ioWRITE(*,'(2x,a,i6,a)') "Going to compute", qpath%nq, " points (2)"
-    
-    DO iq = input%skip_q +1,qpath%nq
-      !CALL print_percent_wall(10._dp, 300._dp, iq, qpath%nq, (iq==1))
       !
-      CALL freq_phq_path(qpath%nq, iq, qpath%xq, S, fc2, w2, D)
-      ioWRITE(*,'(i6,3f12.6,5x,6f12.6,100(/,47x,6f12.6))') iq, qpath%xq(:,iq), w2*RY_TO_CMM1
       !
-      DO it = 1,input%nconf
-        IF(qpath%w(iq)==0._dp .and. iq>1 .and. ionode) THEN
-          CLOSE(1000+it)
-          newfile = newfile+1
-          OPEN(unit=1000+it, position=pos, &
-                    file=TRIM(input%outdir)//"/"//TRIM(input%prefix)//&
-                         "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
-                         "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//&
-                         "_p"//TRIM(int_to_char(newfile))//".out")       
-        ENDIF
-        ioWRITE(1000+it, *)
-        ioWRITE(1000+it, '(a,i6,3f15.8,5x,100(/,"#",6f12.6))') "#  xq",  iq, qpath%xq(:,iq), w2*RY_TO_CMM1
-      ENDDO
+      IF(ionode)THEN
+         DO it = 1,input%nconf
+            CLOSE(unit=1000+it)
+         ENDDO
+      ENDIF
       !
-      IF (TRIM(input%calculation) == "spf") THEN
-        ALLOCATE(spectralf(input%ne,S%nat3,input%nconf))
-        IF (TRIM(input%mode) == "full") THEN
-          UNIT_CONVERSION = 1/RY_TO_CMM1
-          spectralf = spectre_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
-                                    S, grid, fc2, fc3, input%ne, ener, w2, D, shift=.true.)
-        ELSE IF (TRIM(input%mode) == "full2") THEN
-          UNIT_CONVERSION = 1/RY_TO_CMM1
-          spectralf = spectre2_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
-                                    S, grid, fc2, fc3, input%ne, ener, w2, D)
-        ELSE IF (TRIM(input%mode) == "imag") THEN
-          UNIT_CONVERSION = 1/RY_TO_CMM1
-          spectralf = spectre_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
-                                    S, grid, fc2, fc3, input%ne, ener, w2, D, shift=.false.)
-        ELSE IF (TRIM(input%mode) == "simple" .or. TRIM(input%mode) == "isimple") THEN
-          UNIT_CONVERSION = 1/RY_TO_CMM1
-          spectralf = simple_spectre_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
-                                    S, grid, fc2, fc3, input%ne, ener, w2, D, &
-                                    shift=(TRIM(input%mode) == "simple") )
-        ELSE IF (TRIM(input%mode) == "refl") THEN
-          UNIT_CONVERSION = 1._dp
-          IF(ANY(qpath%xq(:,iq)/=0._dp).and.ionode) &
-              WRITE(stdout,*) "WARNING! tilde epsilon out of Gamma makes no sense"        
-          spectralf = ir_reflectivity_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
-                                    S, grid, fc2, fc3, input%ne, ener, w2, D)
-        ELSE
-          CALL errore("SPECTR_QBZ_LINE", 'unknown mode "'//TRIM(input%mode)//'"', 1)
-        ENDIF
-        IF(input%exp_t_factor) CALL add_exp_t_factor(input%nconf, input%T, &
-                        input%ne, S%nat3, ener, spectralf)
-        !
-        DO it = 1,input%nconf
-          DO ie = 1,input%ne
-            ioWRITE(1000+it, '(2f14.8,100e14.6)') &
-                  qpath%w(iq), ener(ie)*RY_TO_CMM1, &
-                  SUM(spectralf(ie,:,it))*UNIT_CONVERSION, &
-                  spectralf(ie,:,it)*UNIT_CONVERSION
+      CALL print_all_timers()
+      !
+      DEALLOCATE(ener)
+      !
+   END SUBROUTINE SPECTR_QBZ_LINE
+   !
+   !
+   SUBROUTINE FINAL_STATE_LINE(input, qpath, S, fc2, fc3)
+      USE fc2_interpolate,  ONLY : fftinterp_mat2, mat2_diag
+      USE final_state,      ONLY : final_state_q, NTERMS, TOT, X, C
+      USE constants,        ONLY : RY_TO_CMM1
+      USE q_grids,          ONLY : q_grid, setup_grid
+      USE more_constants,   ONLY : write_conf
+      USE input_fc,         ONLY : forceconst2_grid, ph_system_info
+      USE fc3_interpolate,  ONLY : forceconst3
+      USE code_input,       ONLY : code_input_type
+      USE timers
+      IMPLICIT NONE
+      !
+      TYPE(code_input_type),INTENT(in)     :: input
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(inout)  :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: qpath
+      !
+      REAL(DP) :: e_inital_ry
+      INTEGER :: iq, it, ie
+      TYPE(q_grid) :: grid
+      COMPLEX(DP):: ls(S%nat3,input%nconf)
+      REAL(DP) :: sigma_ry(input%nconf)
+      !
+      REAL(DP),PARAMETER :: inv2_RY_TO_CMM1 = 1/(RY_TO_CMM1)**2
+      !
+      REAL(DP),ALLOCATABLE :: ener(:), fstate(:,:,:,:)
+      CHARACTER(len=256) :: filename
+      !
+      ALLOCATE(fstate(input%ne,S%nat3,NTERMS,input%nconf))
+      !
+      ioWRITE(*,*) "--> Setting up inner grid"
+      CALL setup_grid(input%grid_type, S%bg, input%nk(1), input%nk(2), input%nk(3), grid, scatter=.true., xq0=input%xk0)
+      !CALL grid%scatter()
+      !
+      ALLOCATE(ener(input%ne))
+      FORALL(ie = 1:input%ne) ener(ie) = (ie-1)*input%de+input%e0
+      ! Convert to Rydberg:
+      ener = ener/RY_TO_CMM1
+      e_inital_ry = input%e_initial/RY_TO_CMM1
+      sigma_ry = input%sigma/RY_TO_CMM1
+      !
+      IF(ionode)THEN
+         DO it = 1,input%nconf
+            filename = TRIM(input%outdir)//"/"//&
+               TRIM(input%prefix)//"_T"//TRIM(write_conf(it,input%nconf,input%T))//&
+               "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out"
+            OPEN(unit=1000+it, file=filename)
+            ioWRITE(*,*) "opening ", TRIM(filename)
+            ioWRITE(1000+it, '(2a)') "# final state decompositions, mode: ", input%mode
+            ioWRITE(1000+it, '(a,i6,a,f6.1,a,100f6.1)') "# conf:", it, "  T=",input%T(it), "   sigma=", input%sigma(it)
+            ioWRITE(1000+it, '(a,3f12.4)') "# xq:", input%q_initial
+            ioWRITE(1000+it, '(a)') "# energy (cm^-1)    total   tot_X tot_C  " &
+               //" tot(band1 band2 ...)  C( band1  band2 ... )  X(band1 band2 ... ) "
             ioFLUSH(1000+it)
-          ENDDO
-        ENDDO
-        DEALLOCATE(spectralf)
-      ELSE 
-        ALLOCATE(caux(input%ne,S%nat3,input%nconf))
-        IF (TRIM(input%calculation) == "eps" .or. &
-            TRIM(input%calculation) == "refl"  ) THEN
-           UNIT_CONVERSION = 1._dp
-           IF(ANY(qpath%xq(:,iq)/=0._dp).and.ionode) WRITE(stdout,*) "WARNING! tilde epsilon out of Gamma makes no sense"
-             caux = tepsilon_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
-                               S, grid, fc2, fc3, input%ne, ener, w2, D)
-           IF(TRIM(input%calculation) == "refl") THEN
-             caux = (SQRT(caux)-1)/(SQRT(caux)+1)
-             caux = caux*CONJG(caux)
-           ENDIF
-        ELSE IF (TRIM(input%calculation) == "selfnrg") THEN
-          UNIT_CONVERSION = RY_TO_CMM1
-          caux = selfnrg_omega_q(qpath%xq(:,iq), input%nconf, input%T, sigma_ry, &
-                                     S, grid, fc2, fc3, input%ne, ener, w2, D)
-        ENDIF
-        !
-        DO it = 1,input%nconf
-          DO ie = 1,input%ne
-            ioWRITE(1000+it, '(2f14.8,100(2e14.6,3x))') &
-                  qpath%w(iq), ener(ie)*RY_TO_CMM1, &
-                  SUM(caux(ie,:,it))*UNIT_CONVERSION, &
-                  caux(ie,:,it)*UNIT_CONVERSION
-            ioFLUSH(1000+it)
-          ENDDO
-        ENDDO
-        !
-      DEALLOCATE(caux)
-     ENDIF
-     !
-    ENDDO
-    !
-    !
-    IF(ionode)THEN
-    DO it = 1,input%nconf
-      CLOSE(unit=1000+it)
-    ENDDO
-    ENDIF
-    !
-    CALL print_all_timers()
-    !
-    DEALLOCATE(ener)
-    !
-  END SUBROUTINE SPECTR_QBZ_LINE
-  !   
-  !  
-  SUBROUTINE FINAL_STATE_LINE(input, qpath, S, fc2, fc3)
-    USE fc2_interpolate,  ONLY : fftinterp_mat2, mat2_diag
-    USE final_state,      ONLY : final_state_q, NTERMS, TOT, X, C
-    USE constants,        ONLY : RY_TO_CMM1
-    USE q_grids,          ONLY : q_grid, setup_grid
-    USE more_constants,   ONLY : write_conf
-    USE input_fc,         ONLY : forceconst2_grid, ph_system_info
-    USE fc3_interpolate,  ONLY : forceconst3
-    USE code_input,       ONLY : code_input_type
-    USE timers
-    IMPLICIT NONE
-    !
-    TYPE(code_input_type),INTENT(in)     :: input
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(inout)  :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: qpath
-    !
-    REAL(DP) :: e_inital_ry 
-    INTEGER :: iq, it, ie
-    TYPE(q_grid) :: grid
-    COMPLEX(DP):: ls(S%nat3,input%nconf)
-    REAL(DP) :: sigma_ry(input%nconf)
-    !
-    REAL(DP),PARAMETER :: inv2_RY_TO_CMM1 = 1/(RY_TO_CMM1)**2
-    !
-    REAL(DP),ALLOCATABLE :: ener(:), fstate(:,:,:,:)
-    CHARACTER(len=256) :: filename
-    !
-    ALLOCATE(fstate(input%ne,S%nat3,NTERMS,input%nconf))
-    !
-    ioWRITE(*,*) "--> Setting up inner grid"
-    CALL setup_grid(input%grid_type, S%bg, input%nk(1), input%nk(2), input%nk(3), grid, scatter=.true., xq0=input%xk0)
-    !CALL grid%scatter()
-    !
-    ALLOCATE(ener(input%ne))
-    FORALL(ie = 1:input%ne) ener(ie) = (ie-1)*input%de+input%e0
-    ! Convert to Rydberg:
-    ener = ener/RY_TO_CMM1
-    e_inital_ry = input%e_initial/RY_TO_CMM1
-    sigma_ry = input%sigma/RY_TO_CMM1
-    !
-    IF(ionode)THEN 
-    DO it = 1,input%nconf
-      filename = TRIM(input%outdir)//"/"//&
-                 TRIM(input%prefix)//"_T"//TRIM(write_conf(it,input%nconf,input%T))//&
-                 "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out"
-      OPEN(unit=1000+it, file=filename)
-      ioWRITE(*,*) "opening ", TRIM(filename)
-      ioWRITE(1000+it, '(2a)') "# final state decompositions, mode: ", input%mode
-      ioWRITE(1000+it, '(a,i6,a,f6.1,a,100f6.1)') "# conf:", it, "  T=",input%T(it), "   sigma=", input%sigma(it)
-      ioWRITE(1000+it, '(a,3f12.4)') "# xq:", input%q_initial
-      ioWRITE(1000+it, '(a)') "# energy (cm^-1)    total   tot_X tot_C  " &
-                          //" tot(band1 band2 ...)  C( band1  band2 ... )  X(band1 band2 ... ) "
-      ioFLUSH(1000+it)
-    ENDDO
-    ENDIF
-    !
-    ioWRITE(*,'(2x,a,3f12.6,a,i4,a,1f12.6,a)') &
-        "Going to compute final state decomposition for", input%q_initial, &
-        "  mode:", input%nu_initial, &
-        "  energy:", input%e_initial, "cm^-1"
-    
+         ENDDO
+      ENDIF
+      !
+      ioWRITE(*,'(2x,a,3f12.6,a,i4,a,1f12.6,a)') &
+         "Going to compute final state decomposition for", input%q_initial, &
+         "  mode:", input%nu_initial, &
+         "  energy:", input%e_initial, "cm^-1"
+
       !
       fstate = input%de*final_state_q(input%q_initial, qpath, input%nconf, input%T, &
-                             sigma_ry, S, grid, fc2, fc3, &
-                             input%nu_initial, e_inital_ry, &
-                             input%ne, ener, input%sigma_e/RY_TO_CMM1, &
-                             input%q_resolved, input%q_summed, input%sigmaq, &
-                             input%outdir, input%prefix, input%mode)
+         sigma_ry, S, grid, fc2, fc3, &
+         input%nu_initial, e_inital_ry, &
+         input%ne, ener, input%sigma_e/RY_TO_CMM1, &
+         input%q_resolved, input%q_summed, input%sigmaq, &
+         input%outdir, input%prefix, input%mode)
       !
       DO it = 1,input%nconf
-        DO ie = 1,input%ne
-          ioWRITE(1000+it, '(1f14.8,100e18.6e3)') &
+         DO ie = 1,input%ne
+            ioWRITE(1000+it, '(1f14.8,100e18.6e3)') &
                ener(ie)*RY_TO_CMM1, SUM(fstate(ie,:,TOT,it)), SUM(fstate(ie,:,C,it)), SUM(fstate(ie,:,X,it)), &
                fstate(ie,:,TOT,it),  fstate(ie,:,C,it), fstate(ie,:,X,it)
-          ioFLUSH(1000+it)
-        ENDDO
+            ioFLUSH(1000+it)
+         ENDDO
       ENDDO
       !
-    !ENDDO
-    !
-    !
-    IF(ionode)THEN
-    DO it = 1,input%nconf
-      CLOSE(unit=1000+it)
-    ENDDO
-    ENDIF
-    !
-    DEALLOCATE(fstate, ener)
-    !
-  END SUBROUTINE FINAL_STATE_LINE
-  !   
-  END MODULE linewidth_program
+      !ENDDO
+      !
+      !
+      IF(ionode)THEN
+         DO it = 1,input%nconf
+            CLOSE(unit=1000+it)
+         ENDDO
+      ENDIF
+      !
+      DEALLOCATE(fstate, ener)
+      !
+   END SUBROUTINE FINAL_STATE_LINE
+   !
+END MODULE linewidth_program
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 !               !               !               !               !               !               !
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 PROGRAM linewidth
 
-  USE kinds,            ONLY : DP
-  USE linewidth_program
-  USE input_fc,         ONLY : forceconst2_grid, ph_system_info
-  USE q_grids,          ONLY : q_grid !, setup_grid
-  USE fc3_interpolate,  ONLY : forceconst3
-  USE code_input,       ONLY : READ_INPUT, code_input_type
-  USE mpi_thermal,      ONLY : start_mpi, stop_mpi, ionode
-  USE more_constants,   ONLY : print_citations_linewidth
-  USE mc_grids,         ONLY : print_optimized_stats
-  IMPLICIT NONE
-  !
-  TYPE(forceconst2_grid) :: fc2
-  CLASS(forceconst3),POINTER :: fc3
-  TYPE(ph_system_info)   :: S
-  TYPE(code_input_type)     :: lwinput
-  TYPE(q_grid)      :: qpath
+   USE kinds,            ONLY : DP
+   USE linewidth_program
+   USE input_fc,         ONLY : forceconst2_grid, ph_system_info
+   USE q_grids,          ONLY : q_grid !, setup_grid
+   USE fc3_interpolate,  ONLY : forceconst3
+   USE code_input,       ONLY : READ_INPUT, code_input_type
+   USE mpi_thermal,      ONLY : start_mpi, stop_mpi, ionode
+   USE more_constants,   ONLY : print_citations_linewidth
+   USE mc_grids,         ONLY : print_optimized_stats
+   IMPLICIT NONE
+   !
+   TYPE(forceconst2_grid) :: fc2
+   CLASS(forceconst3),POINTER :: fc3
+   TYPE(ph_system_info)   :: S
+   TYPE(code_input_type)     :: lwinput
+   TYPE(q_grid)      :: qpath
 
 !   CALL mp_world_start(world_comm)
 !   CALL environment_start('LW')
-  CALL start_mpi()
-  CALL init_nanoclock()
-  !
-  IF(ionode) CALL print_citations_linewidth()
+   CALL start_mpi()
+   CALL init_nanoclock()
+   !
+   IF(ionode) CALL print_citations_linewidth()
 
-  ! READ_INPUT also reads force constants from disk, using subroutine READ_DATA
-  CALL READ_INPUT("LW", lwinput, qpath, S, fc2, fc3)
-  !
-  IF(    TRIM(lwinput%calculation) == "lw"   &
-    .or. TRIM(lwinput%calculation) == "grid" &
-    ) THEN
-    !
-    CALL LW_QBZ_LINE(lwinput, qpath, S, fc2, fc3)
-    !
-  ELSE &
-  IF(TRIM(lwinput%calculation) == "spf" .or. &
-     TRIM(lwinput%calculation) == "eps" .or. &
-     TRIM(lwinput%calculation) == "refl" .or. &
-     TRIM(lwinput%calculation) == "selfnrg") THEN
-    !
-    CALL SPECTR_QBZ_LINE(lwinput, qpath, S, fc2, fc3)
-    !
+   ! READ_INPUT also reads force constants from disk, using subroutine READ_DATA
+   CALL READ_INPUT("LW", lwinput, qpath, S, fc2, fc3)
+   !
+   IF(    TRIM(lwinput%calculation) == "lw"   &
+      .or. TRIM(lwinput%calculation) == "grid" &
+      ) THEN
+      !
+      CALL LW_QBZ_LINE(lwinput, qpath, S, fc2, fc3)
+      !
+   ELSE &
+      IF(TRIM(lwinput%calculation) == "spf" .or. &
+      TRIM(lwinput%calculation) == "eps" .or. &
+      TRIM(lwinput%calculation) == "refl" .or. &
+      TRIM(lwinput%calculation) == "selfnrg") THEN
+      !
+      CALL SPECTR_QBZ_LINE(lwinput, qpath, S, fc2, fc3)
+      !
 !   ELSE &
 !   IF(TRIM(lwinput%calculation) == "grid") THEN
 !     !
 !     ! Compute the linewidth over the grid, will be reused later to do self-consistent linewidth
 !     CALL LW_QBZ_LINE(lwinput, qpath, S, fc2, fc3)
-  ELSE &
-  IF(TRIM(lwinput%calculation) == "final") THEN
-    !
-    CALL FINAL_STATE_LINE(lwinput, qpath, S, fc2, fc3)
-    !
-  ELSE
-    CALL errore("lw", "what else to do?", 1)
-  ENDIF
-  !
-      ioWRITE(stdout,'("   * WALL : ",f12.4," s")') get_wall()
-      CALL print_timers_header()
-      CALL t_lwisot%print()
-      CALL t_lwcasi%print()
-      CALL t_lwphph%print()
-      CALL t_iodata%print()
-      ioWRITE(*,'(a)') "*** * Contributions to ph-ph linewidth time:"
-      CALL t_freq%print()
-      CALL t_bose%print()
-      CALL t_sum%print()
-      CALL t_fc3int%print()
-      CALL t_fc3m2%print()
-      CALL t_fc3rot%print()
-      CALL t_mpicom%print()
-      CALL t_merged%print()
-      CALL t_rigid%print()
-      IF(lwinput%optimize_grid)THEN
+   ELSE &
+      IF(TRIM(lwinput%calculation) == "final") THEN
+      !
+      CALL FINAL_STATE_LINE(lwinput, qpath, S, fc2, fc3)
+      !
+   ELSE
+      CALL errore("lw", "what else to do?", 1)
+   ENDIF
+   !
+   ioWRITE(stdout,'("   * WALL : ",f12.4," s")') get_wall()
+   CALL print_timers_header()
+   CALL t_lwisot%print()
+   CALL t_lwcasi%print()
+   CALL t_lwphph%print()
+   CALL t_iodata%print()
+   ioWRITE(*,'(a)') "*** * Contributions to ph-ph linewidth time:"
+   CALL t_freq%print()
+   CALL t_freqd%print()
+   CALL t_thtetra%print()
+   CALL t_bose%print()
+   CALL t_sum%print()
+   CALL t_fc3int%print()
+   CALL t_fc3m2%print()
+   CALL t_fc3rot%print()
+   CALL t_mpicom%print()
+   CALL t_merged%print()
+   CALL t_rigid%print()
+   IF(lwinput%optimize_grid)THEN
       ioWRITE(*,'(a)') "*** * q-points grid optimization time:"
       CALL t_optimize%print()
       CALL print_optimized_stats()
-      ENDIF
+   ENDIF
 
-  IF(ionode) CALL print_citations_linewidth()
-  CALL stop_mpi()
- 
+   IF(ionode) CALL print_citations_linewidth()
+   CALL stop_mpi()
+
 END PROGRAM
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 

--- a/thermal2/PROGRAM_tk.f90
+++ b/thermal2/PROGRAM_tk.f90
@@ -6,714 +6,715 @@
 !  <http://www.gnu.org/copyleft/gpl.txt>
 !
 MODULE thermalk_program
-  !
+   !
 #include "mpi_thermal.h"
-  USE kinds,       ONLY : DP
-  USE mpi_thermal, ONLY : ionode
-  USE posix_signal,ONLY : check_graceful_termination
-  USE timers
-  !
-  CONTAINS
-  !
-  SUBROUTINE check_negative_lw(lw, nat3, nconf, name)
-    IMPLICIT NONE
-    REAL(DP),INTENT(in) :: lw(nat3, nconf)
-    INTEGER,INTENT(in)  :: nat3, nconf
-    CHARACTER(len=*),INTENT(in) :: name
-    !
-    INTEGER :: i,j
-    IF(ANY(lw<0._dp))THEN
-      DO i = 1,nconf
-        DO j = 1,nat3
-          IF(lw(j,i) < 0._dp) THEN
-            WRITE(*,*) i, j, lw(j,i)
-          ENDIF
-        ENDDO
-      ENDDO
-      CALL errore(name, "negative linewidth", 1)
-    ENDIF
-    RETURN
-  END SUBROUTINE
-  !
-  ! This subroutine computes the SMA thermal conducivity, it is mainly just a driver
-  ! that uses other subroutines to compute th intrinsic, isotopic and casimir linewidths,
-  ! than it sums everything up and takes care of input/output.
-  !
-  ! This subroutine is obsoleted by the first iteration of the variational method,
-  ! but we keep it for didactical purposes. This is also faster, but it does not respect
-  ! the detailed balance exactly (negative tk is possible at low temperature)
-  !
-  ! NOTE: all the *linewidth* functions return the HALF width half maximum, here 
-  ! we multiply by 2 in order to get the full width.
-  SUBROUTINE TK_SMA(input, out_grid, S, fc2, fc3)
-    USE linewidth,          ONLY : linewidth_q
-    USE constants,          ONLY : RY_TO_CMM1, K_BOLTZMANN_RY, tpi
-    USE more_constants,     ONLY : RY_TO_WATTMM1KM1, write_conf, ryvel_si
-    USE q_grids,            ONLY : q_grid, setup_grid
-    USE fc3_interpolate,    ONLY : forceconst3
-    USE isotopes_linewidth, ONLY : isotopic_linewidth_q
-    USE casimir_linewidth,  ONLY : casimir_linewidth_vel, mfp_scatter_vel
-    USE input_fc,           ONLY : ph_system_info
-    USE code_input,         ONLY : code_input_type
-    USE fc2_interpolate,    ONLY : forceconst2_grid, freq_phq_safe, bose_phq
-    USE ph_velocity,        ONLY : velocity, velocity_operator
-    !USE overlap,            ONLY : order_type
-    USE timers
-    IMPLICIT NONE
-    !
-    TYPE(code_input_type),INTENT(in)  :: input
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: out_grid
-    !
-    TYPE(q_grid) :: in_grid
-    REAL(DP) :: sigma_ry(input%nconf)
-    REAL(DP) :: lw(S%nat3,input%nconf)
-    REAL(DP) :: lw_isotopic(S%nat3,input%nconf)
-    REAL(DP) :: lw_phph(S%nat3,input%nconf)
-    REAL(DP) :: lw_casimir(S%nat3)
-    REAL(DP) :: lw_un(S%nat3,2,input%nconf)
-    REAL(DP) :: freq(S%nat3)
-    REAL(DP) :: bose(S%nat3,input%nconf)
-    COMPLEX(DP) :: U(S%nat3,S%nat3)
-    !
-    REAL(DP) :: tk(3,3,input%nconf)
-    REAL(DP) :: vel(3,S%nat3)
-    !
-    COMPLEX(DP) :: tk_P(3,3,input%nconf)
-    COMPLEX(DP) :: tk_C(3,3,input%nconf)
-    COMPLEX(DP) :: vel_operator(3,S%nat3,S%nat3)
-    COMPLEX(DP) :: prefactor
-    REAL(DP) :: Lorentzian, boseplus, boseplus_p, debug_max_imag_k_P, debug_max_imag_k_C
-    !
-    !for debug
-    REAL(DP) :: vel_diag(3,S%nat3)
-    !
-    REAL(DP) :: pref
-    INTEGER  :: iq, it, a, b, nu, id_dir,im, im2, nup, iu
-    character(len=29) :: filename
-    LOGICAL :: condition_print
-    REAL(DP),PARAMETER :: eps_vel = 1.e-12_dp
-    LOGICAL :: gamma
-    !TYPE(order_type) :: order
-    !
-    character*1 tab
-    tab = char(9)
-    sigma_ry = input%sigma/RY_TO_CMM1
-    !
-    ! the inner grid (in_grid) is scatterd over MPI
-    ioWRITE(*,*) "--> Setting up inner grid"
-    CALL setup_grid(input%grid_type_in, S%bg, input%nk_in(1), input%nk_in(2), input%nk_in(3),&
-                    in_grid, scatter=.true., xq0=input%xk0_in)
-    !
-    ! Open files to store the linewidth
-    IF(ionode.and.input%store_lw)THEN
-      DO it = 1,input%nconf
-        IF (input%intrinsic_scattering) THEN
-          OPEN(unit=1000+it, file=TRIM(input%outdir)//"/"//&
-                                  "lw."//TRIM(input%prefix)//&
-                                  "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
-                                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
-          ioWRITE(1000+it, *) "# linewidth [cm^-1]"
-          ioWRITE(1000+it, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, "     T=",input%T(it),&
-                                                      "    sigma=", input%sigma(it)
-          ioFLUSH(1000+it)
-          !
-          iu = 1000+input%nconf+it
-          OPEN(unit=iu, file=TRIM(input%outdir)//"/"//&
-                                  "lw_N."//TRIM(input%prefix)//&
-                                  "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
-                                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
-          ioWRITE(iu, *) "# linewidth NORMAL [cm^-1]"
-          ioWRITE(iu, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, "     T=",input%T(it),&
-                                                      "    sigma=", input%sigma(it)
-          ioFLUSH(iu)
-          !
-          iu = 1000+2*input%nconf+it
-          OPEN(unit=iu, file=TRIM(input%outdir)//"/"//&
-                                  "lw_U."//TRIM(input%prefix)//&
-                                  "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
-                                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
-          ioWRITE(iu, *) "# linewidth UMKLAPP [cm^-1]"
-          ioWRITE(iu, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, "     T=",input%T(it),&
-                                                      "    sigma=", input%sigma(it)
-          ioFLUSH(iu)
+   USE kinds,       ONLY : DP
+   USE mpi_thermal, ONLY : ionode, mpi_bsum
+   USE posix_signal,ONLY : check_graceful_termination
+   USE q_grids,            ONLY : q_grid, setup_grid, fc_info
+   USE timers
+   !
+CONTAINS
+   !
+   ! This subroutine computes the SMA thermal conducivity, it is mainly just a driver
+   ! that uses other subroutines to compute th intrinsic, isotopic and casimir linewidths,
+   ! than it sums everything up and takes care of input/output.
+   !
+   ! This subroutine is obsoleted by the first iteration of the variational method,
+   ! but we keep it for didactical purposes. This is also faster, but it does not respect
+   ! the detailed balance exactly (negative tk is possible at low temperature)
+   !
+   ! NOTE: all the *linewidth* functions return the HALF width half maximum, here
+   ! we multiply by 2 in order to get the full width.
+   SUBROUTINE TK_SMA(input, out_grid, S, fc2, fc3)
+      USE symme,              ONLY : symmatrix
+      USE linewidth,          ONLY : linewidth_q, check_negative_lw
+      USE constants,          ONLY : RY_TO_CMM1, K_BOLTZMANN_RY, tpi
+      USE more_constants,     ONLY : RY_TO_WATTMM1KM1, write_conf, ryvel_si
+      USE q_grids,            ONLY : q_grid, setup_grid
+      USE fc3_interpolate,    ONLY : forceconst3
+      USE isotopes_linewidth, ONLY : isotopic_linewidth_q
+      USE casimir_linewidth,  ONLY : casimir_linewidth_vel, mfp_scatter_vel
+      USE input_fc,           ONLY : ph_system_info
+      USE code_input,         ONLY : code_input_type
+      USE fc2_interpolate,    ONLY : forceconst2_grid, freq_phq_safe, bose_phq
+      USE ph_velocity,        ONLY : velocity, velocity_operator
+      !USE overlap,            ONLY : order_type
+      USE timers
+      IMPLICIT NONE
+      !
+      TYPE(code_input_type),INTENT(in)  :: input
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in), POINTER     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: out_grid
+      !
+      TYPE(q_grid) :: in_grid
+      REAL(DP) :: sigma_ry(input%nconf)
+      REAL(DP) :: lw(S%nat3,input%nconf)
+      REAL(DP) :: lw_isotopic(S%nat3,input%nconf)
+      REAL(DP) :: lw_phph(S%nat3,input%nconf)
+      REAL(DP) :: lw_casimir(S%nat3)
+      REAL(DP) :: lw_un(S%nat3,2,input%nconf)
+      REAL(DP) :: freq(S%nat3)
+      REAL(DP) :: bose(S%nat3,input%nconf)
+      COMPLEX(DP) :: U(S%nat3,S%nat3)
+      !
+      REAL(DP) :: tk(3,3,input%nconf)
+      REAL(DP) :: vel(3,S%nat3)
+      !
+      COMPLEX(DP) :: tk_P(3,3,input%nconf)
+      COMPLEX(DP) :: tk_C(3,3,input%nconf)
+      REAL(DP) :: real_tk_P(3,3,input%nconf), real_tk_C(3,3,input%nconf)
+      COMPLEX(DP) :: vel_operator(3,S%nat3,S%nat3)
+      COMPLEX(DP) :: prefactor
+      REAL(DP) :: Lorentzian, boseplus, boseplus_p, debug_max_imag_k_P, debug_max_imag_k_C
+      !
+      !for debug
+      REAL(DP) :: vel_diag(3,S%nat3)
+      !
+      INTEGER  :: iq, it, a, b, nu, im, im2, nup, iu
+      character(29) :: filename
+      LOGICAL :: condition_print
+      REAL(DP),PARAMETER :: eps_vel = 1.e-12_dp
+      LOGICAL :: gamma
+      !TYPE(order_type) :: order
+      !
+      EXTERNAL errore
+      !
+      character*1 tab
+      tab = char(9)
+      sigma_ry = input%sigma/RY_TO_CMM1
 
-        ENDIF
-        !
-        !
-        IF(input%isotopic_disorder) THEN
-          OPEN(unit=2000+it, file=TRIM(input%outdir)//"/"//&
-                                  "lwiso."//TRIM(input%prefix)//&
-                                      "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
-                                      "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
-          ioWRITE(2000+it, *) "# isotopic linewidth [cm^-1]"
-          ioWRITE(2000+it, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, "     T=",input%T(it),&
-                                                      "    sigma=", input%sigma(it)
-          ioFLUSH(2000+it)
-        ENDIF
-      ENDDO
-      IF(input%casimir_scattering) THEN
-        OPEN(unit=3000, file=TRIM(input%outdir)//"/"//&
-                                "lwcas."//TRIM(input%prefix)//".out")
-        ioWRITE(3000, *) "# casimir linewidth [cm^-1]"
-        ioFLUSH(3000)
-      ENDIF
-      ! Velocity:
-        OPEN(unit=5000, file=TRIM(input%outdir)//"/"//&
-                                "vel."//TRIM(input%prefix)//".out")
-        ioWRITE(5000, *) "# ph group velocity x1, y1, z1, x2, y2, z2, ..."
-        ioFLUSH(5000)
-        OPEN(unit=5001, file=TRIM(input%outdir)//"/"//&
-                                "vel_diag."//TRIM(input%prefix)//".out")
-        ioWRITE(5001, *) "# ph group velocity x1, y1, z1, x2, y2, z2, ..."
-        ioFLUSH(5001)
+      ! the inner grid (in_grid) is scatterd over MPI
+      ioWRITE(*,*) "--> Setting up inner grid"
+      CALL setup_grid(input%grid_type_in, S%bg, input%nk_in(1), input%nk_in(2), input%nk_in(3),&
+         in_grid, scatter=.true., xq0=input%xk0_in)
+      !
+      ! Open files to store the linewidth
+      IF(ionode.and.input%store_lw)THEN
+         DO it = 1,input%nconf
+            IF (input%intrinsic_scattering) THEN
+               OPEN(unit=1000+it, file=TRIM(input%outdir)//"/"//&
+                  "lw."//TRIM(input%prefix)//&
+                  "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
+                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
+               ioWRITE(1000+it, *) "# linewidth [cm^-1]"
+               ioWRITE(1000+it, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, "     T=",input%T(it),&
+                  "    sigma=", input%sigma(it)
+               ioFLUSH(1000+it)
+               !
+               iu = 1000+input%nconf+it
+               OPEN(unit=iu, file=TRIM(input%outdir)//"/"//&
+                  "lw_N."//TRIM(input%prefix)//&
+                  "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
+                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
+               ioWRITE(iu, *) "# linewidth NORMAL [cm^-1]"
+               ioWRITE(iu, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, "     T=",input%T(it),&
+                  "    sigma=", input%sigma(it)
+               ioFLUSH(iu)
+               !
+               iu = 1000+2*input%nconf+it
+               OPEN(unit=iu, file=TRIM(input%outdir)//"/"//&
+                  "lw_U."//TRIM(input%prefix)//&
+                  "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
+                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
+               ioWRITE(iu, *) "# linewidth UMKLAPP [cm^-1]"
+               ioWRITE(iu, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, "     T=",input%T(it),&
+                  "    sigma=", input%sigma(it)
+               ioFLUSH(iu)
 
-        OPEN(unit=6000, file=TRIM(input%outdir)//"/"//&
-                                "freq."//TRIM(input%prefix)//".out")
-        ioWRITE(6000, *) "# phonon frequencies"
-        ioFLUSH(6000)
-        OPEN(unit=7000, file=TRIM(input%outdir)//"/"//&
-                                "q."//TRIM(input%prefix)//".out")
-        ioWRITE(7000, *) "# qpoint [2pi/alat], weight"
-        ioFLUSH(7000)
-    ENDIF
-    !
-    tk = 0._dp
-    tk_P = 0._dp
-    tk_C = 0._dp
-    !
-    IF(input%print_all.and.ionode) THEN
-      open(unit=7022,file=TRIM(input%outdir)//"/"//'phonon_velocity_operator.dat',status='replace')
-      WRITE(7022,'(A)') '#i_q, im1, im2, f_1 (cm^-1), f_2(cm^-1), |V^x|^2, |V^y|^2, |V^z|^2, units (m/s)^2'
-      DO it = 1, input%nconf
-        write(filename, '(A22,i3.3,A4)') TRIM(input%outdir)//"/"//'phonon_properties_raw_',it,'.dat'
-        open(unit=7023+it, file=filename, status='replace')
-        write(7023+it,'(A)') "#  q, mod1, mod2, omega1(Ry),  omega2(Ry),gamma1(Ry),  gamma2(Ry)"
-      END DO
-    ENDIF    
-
-    timer_CALL t_tksma%start()
-    QPOINT_LOOP : &
-    DO iq = 1,out_grid%nq
-      !ioWRITE(stdout,'(i6,3f15.8)') iq, out_grid%xq(:,iq)
-      CALL print_percent_wall(10._dp, 300._dp, iq, out_grid%nq, (iq==1))
-      !
-      IF (input%intrinsic_scattering) THEN
-          timer_CALL t_lwphph%start()
-        lw_phph = linewidth_q(out_grid%xq(:,iq), input%nconf, input%T,&
-                         sigma_ry, S, in_grid, fc2, fc3, lw_un=lw_un)
-        CALL check_negative_lw(lw_phph, S%nat3, input%nconf, "SMA:phph")
-          timer_CALL t_lwphph%stop()
-      ELSE
-        lw_phph = 0._dp
-        IF (input%debug_linewidth) THEN
-          lw_phph = 15._dp/RY_TO_CMM1
-        ENDIF
-      ENDIF
-      !
-      ! Compute contribution of isotopic disorder
-      IF(input%isotopic_disorder)THEN
-          timer_CALL t_lwisot%start()
-        lw_isotopic = isotopic_linewidth_q(out_grid%xq(:,iq), input%nconf, input%T, &
-                                           sigma_ry, S, in_grid, fc2)
-        CALL check_negative_lw(lw_isotopic, S%nat3, input%nconf, "SMA:isotopic")
-          timer_CALL t_lwisot%stop()
-      ELSE
-        lw_isotopic = 0._dp
-      ENDIF
-      !
-      !
-      timer_CALL t_velcty%start()
-      ! Velocity operator
-      !ioWRITE(stdout,"(3x,a)") "velocity_operator start"      
-      vel_operator = velocity_operator( S, fc2, out_grid%xq(:,iq))
-      !
-      !ioWRITE(stdout,"(3x,a)") "velocity_operator end"      
-      ! old subroutine, for debug
-      vel = velocity(S, fc2, out_grid%xq(:,iq))
-        timer_CALL t_velcty%stop()
-      !
-      CALL  freq_phq_safe(out_grid%xq(:,iq), S, fc2, freq, U)
-      !
-      !CALL order%set(S%nat3, freq, U, keep_old_e=.true.)
-      !
-      ! Compute anisotropic Casimir linewidth
-      IF(input%casimir_scattering) THEN
-          timer_CALL t_lwcasi%start()
-        lw_casimir = casimir_linewidth_vel(vel, input%sample_length, input%sample_dir, S%nat3)
-          timer_CALL t_lwcasi%stop()
-      ELSE
-        lw_casimir = 0._dp
-      ENDIF
-      !
-      IF(input%store_lw)THEN
-        timer_CALL t_lwinout%start()
-        DO it = 1, input%nconf
-          IF(input%intrinsic_scattering.and.ionode) THEN 
-            WRITE(1000+it,'(99e20.10)') lw_phph(:,it)*RY_TO_CMM1
-            WRITE(1000+input%nconf+it,'(99e20.10)') lw_un(:,1,it)*RY_TO_CMM1
-            WRITE(1000+2*input%nconf+it,'(99e20.10)') lw_un(:,2,it)*RY_TO_CMM1
-          ENDIF
-          IF(input%isotopic_disorder.and.ionode)    WRITE(2000+it,'(99e20.10)') lw_isotopic(:,it)*RY_TO_CMM1
-        ENDDO
-        IF(input%casimir_scattering) THEN
-          ioWRITE(3000,'(99e20.10)') lw_casimir(:)*RY_TO_CMM1
-        ENDIF
-        ioWRITE(5000,'(3(99e20.10,3x))') vel(:,:)
-        ioWRITE(5001,'(3(99e20.10,3x))') vel_diag(:,:)
-        ioWRITE(6000,'(99e20.10)') freq(:)*RY_TO_CMM1
-        ioWRITE(7000,'(4e20.10)') out_grid%xq(:,iq), out_grid%w(iq)
-        timer_CALL t_lwinout%stop()
-      ENDIF
-      !
-        timer_CALL t_tksum%start()
-      ! Casimir linewidth is temperature/smearing-independent, sum it to all configurations
-      ! Also multiply by 2 in order to get the FULL width from the HALF width
-      ! thanks to Francesco Macheda for reporting this
-      DO it = 1,input%nconf
-        lw(:,it) = 2*(lw_phph(:,it) + lw_isotopic(:,it) + lw_casimir)
-        IF(input%print_all.and.ionode) THEN
-          ! print velocity operator
-          do im=1,S%nat3
-             do im2=1,S%nat3 
-                condition_print=.false.      
-                if (input%workaround_print_v) then     
-                  if (iq==1) then
-                    if (im>3 .and. im2>3) then
-                      condition_print=.true.
-                    end if
-                  else
-                      condition_print=.true.
-                  end if
-                else
-                  condition_print=((lw(im,it)>0.0d0).and.(lw(im2,it)>0.0d0))
-                end if            
-               if ( condition_print .and. (im<=im2)) then
-                if (it==1) then
-                  WRITE(7022 ,'(I6,I4,I4,2ES11.4, 3ES14.7)')       &
-                   iq,im,im2,                                  & 
-                   freq(im)*RY_TO_CMM1,                   &
-                   freq(im2)*RY_TO_CMM1,                  &
-                  ((real(vel_operator(1,im,im2)))**2+     &
-                  (aimag(vel_operator(1,im,im2))**2 ) )   &
-                                         *((tpi*ryvel_si)**2 ), &
-                  ((real(vel_operator(2,im,im2)))**2+     &
-                  (aimag(vel_operator(2,im,im2))**2 ) )   &
-                                         *((tpi*ryvel_si)**2 ), &
-                  ((real(vel_operator(3,im,im2)))**2+     &
-                  (aimag(vel_operator(3,im,im2))**2 ) )   &
-                                         *((tpi*ryvel_si)**2 )
-               endif
-               ! print phonon phonon_properties_raw
-               write(7023+it,'(I6,I4,I4,A1,ES17.10,A1,ES17.10,A1,ES17.10,A1,ES17.10)') &
-                  iq, im,im2,tab,freq(im),tab,freq(im2),tab,lw(im,it),tab,lw(im2,it)
-              end if
-           end do
-         end do
-        END IF
-      ENDDO
-      !
-      CONF_LOOP : &
-      DO it = 1, input%nconf
-        !
-        IF(input%T(it)==0._dp) CYCLE CONF_LOOP
-        !
-        CALL  bose_phq(input%T(it), S%nat3, freq, bose(:,it))
-        !
-        MODE_LOOP : &
-        DO nu = 1, S%nat3
-          ! Check: if we have zero linewidth and non-zero velocity it is a problem
-          ! lw can be NaN when T=0 and xq=0, check for lw>0 instead, because NaN/=0 is true
-          IF(lw(nu,it)<0._dp)THEN ! true for NaN
-            WRITE(stdout,"(3x,a,e12.4,3i6)") &
-               "WARNING! Negative lw (idx q, mode, conf):", lw(nu,it), iq, nu, it
-            lw(nu,it) = - lw(nu,it)
-          ENDIF
-          IF( (.not. lw(nu,it)>0._dp) .and. (input%intrinsic_scattering) )THEN ! false for NaN
-            gamma=(ALL(ABS(out_grid%xq(:,iq))<1.d-12)) 
-            IF((ANY(ABS(vel(:,nu))>eps_vel )) .and.(.not. gamma))THEN
-              WRITE(stdout,'(3i6,1e20.10,5x,3e20.10)') iq, nu, it, lw(nu,it), vel(:,nu)
-              CALL errore("TK_SMA", "Zero or NaN linewidth, with non-zero velocity", 1)
-            ELSE
-              !ioWRITE(stdout,"(3x,a,3i6)") "skip (iq,nu,it):", iq, nu, it
-              CYCLE MODE_LOOP
             ENDIF
-          ENDIF
-          !
-          IF(input%mfp_cutoff)THEN
-            ! Note that lw is already multiplied by 2 here
-            IF( mfp_scatter_vel(vel(:,nu), lw(nu,it), &
-                         input%sample_length, input%sample_dir) ) &
-               CYCLE MODE_LOOP
-          ENDIF
-          !
-          ! end of the safety checks loop 1 
-          ! coherence term
-          boseplus=bose(nu,it)*(1.0+bose(nu,it))
-          DO nup = 1, S%nat3
-            boseplus_p=bose(nup,it)*(1.0+bose(nup,it))
             !
-            prefactor=0.25d0*(freq(nu)+freq(nup))*                                     &
-                          (boseplus*freq(nu)+boseplus_p*freq(nup))*                    &
-                          out_grid%w(iq)/(input%T(it)**2 *S%Omega*K_BOLTZMANN_RY )
             !
-            Lorentzian=  (0.5d0*(lw(nu,it)+lw(nup,it)))/            &
-                         (  (freq(nu)-freq(nup))**2 + (0.5d0*(lw(nu,it)+lw(nup,it)))**2 )
+            IF(input%isotopic_disorder) THEN
+               OPEN(unit=2000+it, file=TRIM(input%outdir)//"/"//&
+                  "lwiso."//TRIM(input%prefix)//&
+                  "_T"//TRIM(write_conf(it,input%nconf,input%T))//&
+                  "_s"//TRIM(write_conf(it,input%nconf,input%sigma))//".out")
+               ioWRITE(2000+it, *) "# isotopic linewidth [cm^-1]"
+               ioWRITE(2000+it, '(a,i6,a,f6.1,a,100f6.1)') "# ", it, "     T=",input%T(it),&
+                  "    sigma=", input%sigma(it)
+               ioFLUSH(2000+it)
+            ENDIF
+         ENDDO
+         IF(input%casimir_scattering) THEN
+            OPEN(unit=3000, file=TRIM(input%outdir)//"/"//&
+               "lwcas."//TRIM(input%prefix)//".out")
+            ioWRITE(3000, *) "# casimir linewidth [cm^-1]"
+            ioFLUSH(3000)
+         ENDIF
+         ! Velocity:
+         OPEN(unit=5000, file=TRIM(input%outdir)//"/"//&
+            "vel."//TRIM(input%prefix)//".out")
+         ioWRITE(5000, *) "# ph group velocity x1, y1, z1, x2, y2, z2, ..."
+         ioFLUSH(5000)
+         OPEN(unit=5001, file=TRIM(input%outdir)//"/"//&
+            "vel_diag."//TRIM(input%prefix)//".out")
+         ioWRITE(5001, *) "# ph group velocity x1, y1, z1, x2, y2, z2, ..."
+         ioFLUSH(5001)
+
+         OPEN(unit=6000, file=TRIM(input%outdir)//"/"//&
+            "freq."//TRIM(input%prefix)//".out")
+         ioWRITE(6000, *) "# phonon frequencies"
+         ioFLUSH(6000)
+         OPEN(unit=7000, file=TRIM(input%outdir)//"/"//&
+            "q."//TRIM(input%prefix)//".out")
+         ioWRITE(7000, *) "# qpoint [2pi/alat], weight"
+         ioFLUSH(7000)
+      ENDIF
+      !
+      tk = 0._dp
+      tk_P = 0._dp
+      tk_C = 0._dp
+      !
+      IF(input%print_all.and.ionode) THEN
+         open(unit=7022,file=TRIM(input%outdir)//"/"//'phonon_velocity_operator.dat',status='replace')
+         WRITE(7022,'(A)') '#i_q, im1, im2, f_1 (cm^-1), f_2(cm^-1), |V^x|^2, |V^y|^2, |V^z|^2, units (m/s)^2'
+         DO it = 1, input%nconf
+            write(filename, '(A22,i3.3,A4)') TRIM(input%outdir)//"/"//'phonon_properties_raw_',it,'.dat'
+            open(unit=7023+it, file=filename, status='replace')
+            write(7023+it,'(A)') "#  q, mod1, mod2, omega1(Ry),  omega2(Ry),gamma1(Ry),  gamma2(Ry)"
+         END DO
+      ENDIF
+
+      timer_CALL t_tksma%start()
+      QPOINT_LOOP : &
+         DO iq = 1,out_grid%nq
+         !ioWRITE(stdout,'(i6,3f15.8)') iq, out_grid%xq(:,iq)
+         CALL print_percent_wall(10._dp, 300._dp, iq, out_grid%nq, (iq==1))
+         !
+         IF (input%intrinsic_scattering) THEN
+            timer_CALL t_lwphph%start()
+            lw_phph = linewidth_q(out_grid%xq(:,iq), S, fc2, fc3, in_grid, input, lw_UN=lw_UN)
+            CALL check_negative_lw(lw_phph, out_grid%xq(:,iq), S%nat3, input%nconf, "SMA:phph")
+            timer_CALL t_lwphph%stop()
+         ELSE
+            lw_phph = 0._dp
+            IF (input%debug_linewidth) THEN
+               lw_phph = 15._dp/RY_TO_CMM1
+            ENDIF
+         ENDIF
+         !
+         ! Compute contribution of isotopic disorder
+         IF(input%isotopic_disorder)THEN
+            timer_CALL t_lwisot%start()
+            lw_isotopic = isotopic_linewidth_q(out_grid%xq(:,iq), input%nconf, input%T, &
+               sigma_ry, S, in_grid, fc2)
+            CALL check_negative_lw(lw_isotopic,  out_grid%xq(:,iq), S%nat3, input%nconf, "SMA:isotopic")
+            timer_CALL t_lwisot%stop()
+         ELSE
+            lw_isotopic = 0._dp
+         ENDIF
+         !
+         !
+         timer_CALL t_velcty%start()
+         ! Velocity operator
+         !ioWRITE(stdout,"(3x,a)") "velocity_operator start"
+         vel_operator = velocity_operator( S, fc2, out_grid%xq(:,iq))
+         !
+         !ioWRITE(stdout,"(3x,a)") "velocity_operator end"
+         ! old subroutine, for debug
+         vel = velocity(S, fc2, out_grid%xq(:,iq))
+         timer_CALL t_velcty%stop()
+         !
+         CALL  freq_phq_safe(out_grid%xq(:,iq), S, fc2, freq, U)
+         !
+         !CALL order%set(S%nat3, freq, U, keep_old_e=.true.)
+         !
+         ! Compute anisotropic Casimir linewidth
+         IF(input%casimir_scattering) THEN
+            timer_CALL t_lwcasi%start()
+            lw_casimir = casimir_linewidth_vel(vel, input%sample_length, input%sample_dir, S%nat3)
+            timer_CALL t_lwcasi%stop()
+         ELSE
+            lw_casimir = 0._dp
+         ENDIF
+         !
+         IF(input%store_lw)THEN
+            timer_CALL t_lwinout%start()
+            DO it = 1, input%nconf
+               IF(input%intrinsic_scattering.and.ionode) THEN
+                  WRITE(1000+it,'(99e20.10)') lw_phph(:,it)*RY_TO_CMM1
+                  WRITE(1000+input%nconf+it,'(99e20.10)') lw_un(:,1,it)*RY_TO_CMM1
+                  WRITE(1000+2*input%nconf+it,'(99e20.10)') lw_un(:,2,it)*RY_TO_CMM1
+               ENDIF
+               IF(input%isotopic_disorder.and.ionode)    WRITE(2000+it,'(99e20.10)') lw_isotopic(:,it)*RY_TO_CMM1
+            ENDDO
+            IF(input%casimir_scattering) THEN
+               ioWRITE(3000,'(99e20.10)') lw_casimir(:)*RY_TO_CMM1
+            ENDIF
+            ioWRITE(5000,'(3(99e20.10,3x))') vel(:,:)
+            ioWRITE(5001,'(3(99e20.10,3x))') vel_diag(:,:)
+            ioWRITE(6000,'(99e20.10)') freq(:)*RY_TO_CMM1
+            ioWRITE(7000,'(4e20.10)') out_grid%xq(:,iq), out_grid%w(iq)
+            timer_CALL t_lwinout%stop()
+         ENDIF
+         !
+         timer_CALL t_tksum%start()
+         ! Casimir linewidth is temperature/smearing-independent, sum it to all configurations
+         ! Also multiply by 2 in order to get the FULL width from the HALF width
+         ! thanks to Francesco Macheda for reporting this
+         DO it = 1,input%nconf
+            lw(:,it) = 2*(lw_phph(:,it) + lw_isotopic(:,it) + lw_casimir)
+            IF(input%print_all.and.ionode) THEN
+               ! print velocity operator
+               do im=1,S%nat3
+                  do im2=1,S%nat3
+                     condition_print=.false.
+                     if (input%workaround_print_v) then
+                        if (iq==1) then
+                           if (im>3 .and. im2>3) then
+                              condition_print=.true.
+                           end if
+                        else
+                           condition_print=.true.
+                        end if
+                     else
+                        condition_print=((lw(im,it)>0.0d0).and.(lw(im2,it)>0.0d0))
+                     end if
+                     if ( condition_print .and. (im<=im2)) then
+                        if (it==1) then
+                           WRITE(7022 ,'(I6,I4,I4,2ES11.4, 3ES14.7)')       &
+                              iq,im,im2,                                  &
+                              freq(im)*RY_TO_CMM1,                   &
+                              freq(im2)*RY_TO_CMM1,                  &
+                              ((real(vel_operator(1,im,im2)))**2+     &
+                              (aimag(vel_operator(1,im,im2))**2 ) )   &
+                              *((tpi*ryvel_si)**2 ), &
+                              ((real(vel_operator(2,im,im2)))**2+     &
+                              (aimag(vel_operator(2,im,im2))**2 ) )   &
+                              *((tpi*ryvel_si)**2 ), &
+                              ((real(vel_operator(3,im,im2)))**2+     &
+                              (aimag(vel_operator(3,im,im2))**2 ) )   &
+                              *((tpi*ryvel_si)**2 )
+                        endif
+                        ! print phonon phonon_properties_raw
+                        write(7023+it,'(I6,I4,I4,A1,ES17.10,A1,ES17.10,A1,ES17.10,A1,ES17.10)') &
+                           iq, im,im2,tab,freq(im),tab,freq(im2),tab,lw(im,it),tab,lw(im2,it)
+                     end if
+                  end do
+               end do
+            END IF
+         ENDDO
+         !
+         CONF_LOOP : &
+            DO it = 1, input%nconf
             !
-            IF ((lw(nu,it)>0.0d0) .and. (lw(nup,it)>0.0d0)) THEN
-              DO a = 1,3
-                DO b = 1,3
-                  IF ( nu == nup) THEN
-                    tk_P(a,b,it) = tk_P(a,b,it) + prefactor*Lorentzian*    &
-                        (vel_operator(a,nu,nup)*vel_operator(b,nup,nu))
+            IF(input%T(it)==0._dp) CYCLE CONF_LOOP
+            !
+            CALL  bose_phq(input%T(it), S%nat3, freq, bose(:,it))
+            !
+            MODE_LOOP : &
+               DO nu = 1, S%nat3
+               ! Check: if we have zero linewidth and non-zero velocity it is a problem
+               ! lw can be NaN when T=0 and xq=0, check for lw>0 instead, because NaN/=0 is true
+               IF(lw(nu,it)<0._dp)THEN ! true for NaN
+                  WRITE(stdout,"(3x,a,e12.4,3i6)") &
+                     "WARNING! Negative lw (idx q, mode, conf):", lw(nu,it), iq, nu, it
+                  lw(nu,it) = - lw(nu,it)
+               ENDIF
+               IF( (.not. lw(nu,it)>0._dp) .and. (input%intrinsic_scattering) )THEN ! false for NaN
+                  gamma=(ALL(ABS(out_grid%xq(:,iq))<1.d-12))
+                  IF((ANY(ABS(vel(:,nu))>eps_vel )) .and.(.not. gamma))THEN
+                     WRITE(stdout,'(3i6,1e20.10,5x,3e20.10)') iq, nu, it, lw(nu,it), vel(:,nu)
+                     CALL errore("TK_SMA", "Zero or NaN linewidth, with non-zero velocity", 1)
                   ELSE
-                    tk_C(a,b,it) = tk_C(a,b,it) + prefactor*Lorentzian*    &
-                        (vel_operator(a,nu,nup)*vel_operator(b,nup,nu))
+                     !ioWRITE(stdout,"(3x,a,3i6)") "skip (iq,nu,it):", iq, nu, it
+                     CYCLE MODE_LOOP
                   ENDIF
-                ENDDO
-              ENDDO
-            ENDIF
-          ENDDO ! end second mode loop
-        ENDDO MODE_LOOP
-        !
-      ENDDO CONF_LOOP
-        timer_CALL t_tksum%stop()
-      !
-    ENDDO QPOINT_LOOP
+               ENDIF
+               !
+               IF(input%mfp_cutoff)THEN
+                  ! Note that lw is already multiplied by 2 here
+                  IF( mfp_scatter_vel(vel(:,nu), lw(nu,it), &
+                     input%sample_length, input%sample_dir) ) &
+                     CYCLE MODE_LOOP
+               ENDIF
+               !
+               ! end of the safety checks loop 1
+               ! coherence term
+               boseplus=bose(nu,it)*(1.0+bose(nu,it))
+               DO nup = 1, S%nat3
+                  boseplus_p=bose(nup,it)*(1.0+bose(nup,it))
+                  !
+                  prefactor=0.25d0*(freq(nu)+freq(nup))*                                     &
+                     (boseplus*freq(nu)+boseplus_p*freq(nup))*                    &
+                     out_grid%w(iq)/(input%T(it)**2 *S%Omega*K_BOLTZMANN_RY )
+                  !
+                  Lorentzian=  (0.5d0*(lw(nu,it)+lw(nup,it)))/            &
+                     (  (freq(nu)-freq(nup))**2 + (0.5d0*(lw(nu,it)+lw(nup,it)))**2 )
+                  !
+                  IF ((lw(nu,it)>0.0d0) .and. (lw(nup,it)>0.0d0)) THEN
+                     DO a = 1,3
+                        DO b = 1,3
+                           IF ( nu == nup) THEN
+                              tk_P(a,b,it) = tk_P(a,b,it) + prefactor*Lorentzian*    &
+                                 (vel_operator(a,nu,nup)*vel_operator(b,nup,nu))
+                           ELSE
+                              tk_C(a,b,it) = tk_C(a,b,it) + prefactor*Lorentzian*    &
+                                 (vel_operator(a,nu,nup)*vel_operator(b,nup,nu))
+                           ENDIF
+                        ENDDO
+                     ENDDO
+                  ENDIF
+               ENDDO ! end second mode loop
+            ENDDO MODE_LOOP
+            !
+         ENDDO CONF_LOOP
+         timer_CALL t_tksum%stop()
+         !
+      ENDDO QPOINT_LOOP
+
+      IF(out_grid%scattered) CALL mpi_bsum(3,3,input%nconf,tk_P)
+      IF(out_grid%scattered) CALL mpi_bsum(3,3,input%nconf,tk_C)
+
       timer_CALL t_tksma%stop()
 
-    IF(ionode.and.input%store_lw)THEN
-      DO it = 1, input%nconf
-        IF(input%intrinsic_scattering) CLOSE(1000+it)
-        IF(input%isotopic_disorder)    CLOSE(2000+it)
-      ENDDO
-      IF(input%casimir_scattering) CLOSE(3000)
-      CLOSE(5000) !velocity
-      CLOSE(5001) !diagonal elements velocity operator
-      CLOSE(6000) ! freq
-      CLOSE(7000) ! q-points
-    ENDIF
-    IF(ionode.and.input%print_all)THEN
-      CLOSE(7022)
-      DO it = 1, input%nconf
-        close(7023+it)
-      END DO
-    ENDIF
-    !
-    IF(input%intrinsic_scattering .or. input%debug_linewidth ) THEN
-      ! Write to disk
-      !      
-      IF(ionode) OPEN(unit=10001, file=TRIM(input%outdir)//"/"//&
-                                       TRIM(input%prefix)//"_P_sma."//"out")
-      IF(ionode) OPEN(unit=10002, file=TRIM(input%outdir)//"/"//&
-                                       TRIM(input%prefix)//"_C."//"out")  
-      IF(ionode) OPEN(unit=10003, file=TRIM(input%outdir)//"/"//&
-                                       TRIM(input%prefix)//"_TOT."//"out")                                             
+      ! We need real tk to symmetrize
+      IF(input%use_symm) THEN
+         real_tk_C = REAL(tk_C, kind=DP)
+         real_tk_P = REAL(tk_P, kind=DP)
+         IF(ionode) THEN
+            DO it = 1, input%nconf
+               CALL symmatrix(real_tk_P(:,:,it))
+               CALL symmatrix(real_tk_C(:,:,it))
+            ENDDO
+         ENDIF
+         tk_C = CMPLX(real_tk_C, AIMAG(tk_C))
+         tk_P = CMPLX(real_tk_P, AIMAG(tk_P))
+      ENDIF
 
-      ioWRITE(10001,'(4a)') "#conf  sigma[cmm1]   T[K]  ",&
-                          "    K_P^x            K_P^y            K_P^z             ",&
-                          "    K_P^xy           K_P^xz           K_P^yz            ",&
-                          "    K_P^yx           K_P^zx           K_P^zy       "
-
-      ioWRITE(10002,'(4a)') "#conf  sigma[cmm1]   T[K]  ",&
-                          "    K_C^x            K_C^y            K_C^z             ",&
-                          "    K_C^xy           K_C^xz           K_C^yz            ",&
-                          "    K_C^yx           K_C^zx           K_C^zy       "
-
-      ioWRITE(10003,'(4a)') "#conf  sigma[cmm1]   T[K]  ",&
-                          "    K_TOT^x            K_TOT^y            K_TOT^z             ",&
-                          "    K_TOT^xy           K_TOT^xz           K_TOT^yz            ",&
-                          "    K_TOT^yx           K_TOT^zx           K_TOT^zy       "
-      tk = tk*RY_TO_WATTMM1KM1
-
-      tk_P = tk_P*RY_TO_WATTMM1KM1
-      tk_C = tk_C*RY_TO_WATTMM1KM1
-
-      debug_max_imag_k_P=maxval(abs(aimag(tk_P)))
-      debug_max_imag_k_C=maxval(abs(aimag(tk_C)))
-
-      DO it = 1,input%nconf
-        !
-        ioWRITE(10001,"(i3,2f12.6,3(3e15.6,5x))") it, input%sigma(it), input%T(it), &
-        REAL(tk_P(1,1,it)),REAL(tk_P(2,2,it)),REAL(tk_P(3,3,it)), &
-        REAL(tk_P(1,2,it)),REAL(tk_P(1,3,it)),REAL(tk_P(2,3,it)), &
-        REAL(tk_P(2,1,it)),REAL(tk_P(3,1,it)),REAL(tk_P(3,2,it))
-        !
-        ioWRITE(10002,"(i3,2f12.6,3(3e15.6,5x))") it, input%sigma(it), input%T(it), &
-        REAL(tk_C(1,1,it)),REAL(tk_C(2,2,it)),REAL(tk_C(3,3,it)), &
-        REAL(tk_C(1,2,it)),REAL(tk_C(1,3,it)),REAL(tk_C(2,3,it)), &
-        REAL(tk_C(2,1,it)),REAL(tk_C(3,1,it)),REAL(tk_C(3,2,it))
-        !
-        ioWRITE(10003,"(i3,2f12.6,3(3e15.6,5x))") it, input%sigma(it), input%T(it), &
-        REAL(tk_P(1,1,it)+tk_C(1,1,it)),REAL(tk_P(2,2,it)+tk_C(2,2,it)),REAL(tk_P(3,3,it)+tk_C(3,3,it)), &
-        REAL(tk_P(1,2,it)+tk_C(1,2,it)),REAL(tk_P(1,3,it)+tk_C(1,3,it)),REAL(tk_P(2,3,it)+tk_C(2,3,it)), &
-        REAL(tk_P(2,1,it)+tk_C(2,1,it)),REAL(tk_P(3,1,it)+tk_C(3,1,it)),REAL(tk_P(3,2,it)+tk_C(3,2,it))
-      ENDDO
-      IF(ionode) CLOSE(10001)
-      IF(ionode) CLOSE(10002)
-      IF(ionode) CLOSE(10003)
-
+      IF(ionode.and.input%store_lw)THEN
+         DO it = 1, input%nconf
+            IF(input%intrinsic_scattering) CLOSE(1000+it)
+            IF(input%isotopic_disorder)    CLOSE(2000+it)
+         ENDDO
+         IF(input%casimir_scattering) CLOSE(3000)
+         CLOSE(5000) !velocity
+         CLOSE(5001) !diagonal elements velocity operator
+         CLOSE(6000) ! freq
+         CLOSE(7000) ! q-points
+      ENDIF
+      IF(ionode.and.input%print_all)THEN
+         CLOSE(7022)
+         DO it = 1, input%nconf
+            close(7023+it)
+         END DO
+      ENDIF
       !
-      ! Write to screen
-      ioWRITE(stdout,"(3x,a,/,3x,a)") "************", "SMA thermal conductivity, stored to file:"
-      ioWRITE(stdout,'(5x,a)') TRIM(input%outdir)//"/"//TRIM(input%prefix)//"."//"out"
+      IF(input%intrinsic_scattering .or. input%debug_linewidth ) THEN
+         ! Write to disk
+         !
+         IF(ionode) OPEN(unit=10001, file=TRIM(input%outdir)//"/"//&
+            TRIM(input%prefix)//"_P_sma."//"out")
+         IF(ionode) OPEN(unit=10002, file=TRIM(input%outdir)//"/"//&
+            TRIM(input%prefix)//"_C."//"out")
+         IF(ionode) OPEN(unit=10003, file=TRIM(input%outdir)//"/"//&
+            TRIM(input%prefix)//"_TOT."//"out")
+
+         ioWRITE(10001,'(4a)') "#conf  sigma[cmm1]   T[K]  ",&
+            "    K_P^x            K_P^y            K_P^z             ",&
+            "    K_P^xy           K_P^xz           K_P^yz            ",&
+            "    K_P^yx           K_P^zx           K_P^zy       "
+
+         ioWRITE(10002,'(4a)') "#conf  sigma[cmm1]   T[K]  ",&
+            "    K_C^x            K_C^y            K_C^z             ",&
+            "    K_C^xy           K_C^xz           K_C^yz            ",&
+            "    K_C^yx           K_C^zx           K_C^zy       "
+
+         ioWRITE(10003,'(4a)') "#conf  sigma[cmm1]   T[K]  ",&
+            "    K_TOT^x            K_TOT^y            K_TOT^z             ",&
+            "    K_TOT^xy           K_TOT^xz           K_TOT^yz            ",&
+            "    K_TOT^yx           K_TOT^zx           K_TOT^zy       "
+         tk = tk*RY_TO_WATTMM1KM1
+
+         tk_P = tk_P*RY_TO_WATTMM1KM1
+         tk_C = tk_C*RY_TO_WATTMM1KM1
+
+         debug_max_imag_k_P=maxval(abs(aimag(tk_P)))
+         debug_max_imag_k_C=maxval(abs(aimag(tk_C)))
+
+         DO it = 1,input%nconf
+            !
+            ioWRITE(10001,"(i3,2f12.6,3(3e15.6,5x))") it, input%sigma(it), input%T(it), &
+               REAL(tk_P(1,1,it)),REAL(tk_P(2,2,it)),REAL(tk_P(3,3,it)), &
+               REAL(tk_P(1,2,it)),REAL(tk_P(1,3,it)),REAL(tk_P(2,3,it)), &
+               REAL(tk_P(2,1,it)),REAL(tk_P(3,1,it)),REAL(tk_P(3,2,it))
+            !
+            ioWRITE(10002,"(i3,2f12.6,3(3e15.6,5x))") it, input%sigma(it), input%T(it), &
+               REAL(tk_C(1,1,it)),REAL(tk_C(2,2,it)),REAL(tk_C(3,3,it)), &
+               REAL(tk_C(1,2,it)),REAL(tk_C(1,3,it)),REAL(tk_C(2,3,it)), &
+               REAL(tk_C(2,1,it)),REAL(tk_C(3,1,it)),REAL(tk_C(3,2,it))
+            !
+            ioWRITE(10003,"(i3,2f12.6,3(3e15.6,5x))") it, input%sigma(it), input%T(it), &
+               REAL(tk_P(1,1,it)+tk_C(1,1,it)),REAL(tk_P(2,2,it)+tk_C(2,2,it)),REAL(tk_P(3,3,it)+tk_C(3,3,it)), &
+               REAL(tk_P(1,2,it)+tk_C(1,2,it)),REAL(tk_P(1,3,it)+tk_C(1,3,it)),REAL(tk_P(2,3,it)+tk_C(2,3,it)), &
+               REAL(tk_P(2,1,it)+tk_C(2,1,it)),REAL(tk_P(3,1,it)+tk_C(3,1,it)),REAL(tk_P(3,2,it)+tk_C(3,2,it))
+         ENDDO
+         IF(ionode) CLOSE(10001)
+         IF(ionode) CLOSE(10002)
+         IF(ionode) CLOSE(10003)
+
+         !
+         ! Write to screen
+         ioWRITE(stdout,"(3x,a,/,3x,a)") "************", "SMA thermal conductivity, stored to file:"
+         ioWRITE(stdout,'(5x,a)') TRIM(input%outdir)//"/"//TRIM(input%prefix)//"."//"out"
+         !
+         ioWRITE(stdout,"(3x,a)") "Thermal conductivity  (conf, sigma, T, K_x, K_y, K_z):"
+         DO it = 1,input%nconf
+            ioWRITE(stdout,"(a7,i3,2f12.6,3e16.8)") 'K_P   =', it, input%sigma(it), input%T(it),&
+               REAL(tk_P(1,1,it)), REAL(tk_P(2,2,it)), REAL(tk_P(3,3,it))
+            ioWRITE(stdout,"(a7,i3,2f12.6,3e16.8)") 'K_C   =', it, input%sigma(it), input%T(it),&
+               REAL(tk_C(1,1,it)), REAL(tk_C(2,2,it)), REAL(tk_C(3,3,it))
+            ioWRITE(stdout,"(a7,i3,2f12.6,3e16.8)") 'K_TOT =', it, input%sigma(it), input%T(it),&
+               REAL(tk_P(1,1,it)+tk_C(1,1,it)), REAL(tk_P(2,2,it)+tk_C(2,2,it)),&
+               REAL(tk_P(3,3,it)+tk_C(3,3,it))
+         ENDDO
+      ELSE
+         ioWRITE(stdout,"(3x,a,/,3x,a)") "************", "SMA thermal conductivity not computed (intrinsic_scattering is false)"
+      ENDIF
       !
-      ioWRITE(stdout,"(3x,a)") "Thermal conductivity  (conf, sigma, T, K_x, K_y, K_z):"
-      DO it = 1,input%nconf
-        ioWRITE(stdout,"(a7,i3,2f12.6,3e16.8)") 'K_P   =', it, input%sigma(it), input%T(it),&
-                                        REAL(tk_P(1,1,it)), REAL(tk_P(2,2,it)), REAL(tk_P(3,3,it))
-        ioWRITE(stdout,"(a7,i3,2f12.6,3e16.8)") 'K_C   =', it, input%sigma(it), input%T(it),&
-                                        REAL(tk_C(1,1,it)), REAL(tk_C(2,2,it)), REAL(tk_C(3,3,it))
-        ioWRITE(stdout,"(a7,i3,2f12.6,3e16.8)") 'K_TOT =', it, input%sigma(it), input%T(it),&
-                           REAL(tk_P(1,1,it)+tk_C(1,1,it)), REAL(tk_P(2,2,it)+tk_C(2,2,it)),&
-                           REAL(tk_P(3,3,it)+tk_C(3,3,it))                                                                
-      ENDDO
-    ELSE
-      ioWRITE(stdout,"(3x,a,/,3x,a)") "************", "SMA thermal conductivity not computed (intrinsic_scattering is false)"
-    ENDIF
-    !
 #ifdef timer_CALL
-    ioWRITE(stdout,'("   * WALL : ",f12.4," s")') get_wall()
-    CALL print_timers_header()
-    CALL t_tksma%print()
-    ioWRITE(stdout,'(a)') "*** * Contributions to SMA conductivity:"
-    CALL t_tksum%print()
-    CALL t_lwisot%print()
-    CALL t_lwcasi%print()
-    CALL t_lwphph%print()
-    CALL t_velcty%print()
-    CALL t_lwinout%print()
-    CALL t_mpicom%print()
-    CALL t_readdt%print()
-    ioWRITE(stdout,'(a)') "*** * Contributions to ph-ph linewidth time:"
-    CALL t_freq%print()
-    CALL t_bose%print()
-    CALL t_sum%print()
-    CALL t_fc3int%print()
-    CALL t_fc3m2%print()
-    CALL t_fc3rot%print()
-    CALL t_merged%print()
+      ioWRITE(stdout,'("   * WALL : ",f12.4," s")') get_wall()
+      CALL print_timers_header()
+      CALL t_tksma%print()
+      ioWRITE(stdout,'(a)') "*** * Contributions to SMA conductivity:"
+      CALL t_tksum%print()
+      CALL t_lwisot%print()
+      CALL t_lwcasi%print()
+      CALL t_lwphph%print()
+      CALL t_velcty%print()
+      CALL t_lwinout%print()
+      CALL t_mpicom%print()
+      CALL t_readdt%print()
+      ioWRITE(stdout,'(a)') "*** * Contributions to ph-ph linewidth time:"
+      CALL t_freq%print()
+      CALL t_freqd%print()
+      CALL t_thtetra%print()
+      CALL t_bose%print()
+      CALL t_sum%print()
+      CALL t_fc3int%print()
+      CALL t_fc3m2%print()
+      CALL t_fc3rot%print()
+      CALL t_merged%print()
 #endif
-    !
-    !
-  END SUBROUTINE TK_SMA
-  !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
-  SUBROUTINE TK_CG_prec(input, out_grid, S, fc2, fc3)
-    USE fc2_interpolate,    ONLY : fftinterp_mat2, mat2_diag, freq_phq
-    USE linewidth,          ONLY : linewidth_q
-    !USE constants,          ONLY : RY_TO_CMM1
-     USE more_constants,     ONLY : RY_TO_WATTMM1KM1!, write_conf
-    USE fc3_interpolate,    ONLY : forceconst3
-    !USE isotopes_linewidth, ONLY : isotopic_linewidth_q
-    !USE casimir_linewidth,  ONLY : casimir_linewidth_q
-    USE input_fc,           ONLY : forceconst2_grid, ph_system_info
-    USE code_input,         ONLY : code_input_type
-    USE q_grids,            ONLY : q_grid, q_basis, setup_grid, setup_bz_grid, &
-                                   prepare_q_basis, qbasis_dot, qbasis_ax, &
-                                   qbasis_a_over_b
-    USE variational_tk
-    IMPLICIT NONE
-    !
-    TYPE(code_input_type),INTENT(in)     :: input
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: out_grid
-    !
-    INTEGER :: ix, nu, iq, it, nu0, iter, iter0
-    !
-    TYPE(q_grid)         :: in_grid ! inner grid is MPI-scattered it is used
-                                    ! for integrating the ph-ph scattering terms and linewidth
-    !
-    TYPE(q_basis) :: qbasis
-    REAL(DP),ALLOCATABLE :: A_out(:,:,:), inv_sqrt_A_out(:,:,:), inv_A_out(:,:,:)
-    REAL(DP),ALLOCATABLE :: f(:,:,:,:), g(:,:,:,:), &
-                            h(:,:,:,:), t(:,:,:,:)!, j(:,:,:,:)
-    REAL(DP),ALLOCATABLE :: Af(:,:,:,:)
-    REAL(DP),ALLOCATABLE :: g_dot_h(:,:), h_dot_t(:,:), &
-                            g_mod2(:,:), g_mod2_old(:,:), &
-                            pref(:,:)
-    REAL(DP) :: tk(3,3,input%nconf), delta_tk(3,3,input%nconf), &
-                tk_old(3,3,input%nconf)
-    LOGICAL :: conv
+      !
+      !
+   END SUBROUTINE TK_SMA
+   !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
+   SUBROUTINE TK_CG_prec(input, out_grid, S, fc2, fc3)
+      USE fc2_interpolate,    ONLY : fftinterp_mat2, mat2_diag, freq_phq
+      !USE constants,          ONLY : RY_TO_CMM1
+      USE more_constants,     ONLY : RY_TO_WATTMM1KM1!, write_conf
+      USE fc3_interpolate,    ONLY : forceconst3
+      !USE isotopes_linewidth, ONLY : isotopic_linewidth_q
+      !USE casimir_linewidth,  ONLY : casimir_linewidth_q
+      USE input_fc,           ONLY : forceconst2_grid, ph_system_info
+      USE code_input,         ONLY : code_input_type
+      USE q_grids,            ONLY : q_grid, q_basis, setup_grid, setup_bz_grid, &
+         prepare_q_basis, qbasis_dot, qbasis_ax, &
+         qbasis_a_over_b
+      USE variational_tk
+      IMPLICIT NONE
+      !
+      TYPE(code_input_type),INTENT(in)     :: input
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in), pointer     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: out_grid
+      !
+      INTEGER :: iter, iter0
+      !
+      TYPE(q_grid)         :: in_grid ! inner grid is MPI-scattered it is used
+      ! for integrating the ph-ph scattering terms and linewidth
+      !
+      TYPE(q_basis) :: qbasis
+      REAL(DP),ALLOCATABLE :: A_out(:,:,:), inv_sqrt_A_out(:,:,:)
+      REAL(DP),ALLOCATABLE :: f(:,:,:,:), g(:,:,:,:), &
+         h(:,:,:,:), t(:,:,:,:)!, j(:,:,:,:)
+      REAL(DP),ALLOCATABLE :: g_dot_h(:,:), h_dot_t(:,:), &
+         g_mod2(:,:), g_mod2_old(:,:), &
+         pref(:,:)
+      REAL(DP) :: tk(3,3,input%nconf), delta_tk(3,3,input%nconf), &
+         tk_old(3,3,input%nconf)
+      LOGICAL :: conv
 !     CHARACTER(len=6) :: what
 !     CHARACTER(len=256) :: filename
-    !
-    ! For code readability:
-    LOGICAL :: restart_ok
-    INTEGER :: nconf, nat3, nq
-    nconf = input%nconf
-    nat3  = S%nat3
-    nq    = out_grid%nq
+      !
+      ! For code readability:
+      LOGICAL :: restart_ok
+      INTEGER :: nconf, nat3, nq
+      nconf = input%nconf
+      nat3  = S%nat3
+      nq    = out_grid%nq
 
-        timer_CALL t_tkprec%start()
-    ! make the inner grid on top of the outer one, they are actually identical
-    ! but the inner one is MPI-scattered, so we need two separate objects to store them
-    ioWRITE(*,*) "--> Setting up inner grid from outer grid"
-    ! Grid type here is always "simple" because we want to reuse the eventual random
-    ! shift from the outer grid (using two different shifts would not work)
-    CALL setup_grid("simple", S%bg, out_grid%n(1),out_grid%n(2),out_grid%n(3), &
-                    in_grid, xq0=out_grid%xq0, scatter=.true.)
-    CALL prepare_q_basis(out_grid, qbasis, nconf, input%T, S, fc2)
+      timer_CALL t_tkprec%start()
+      ! make the inner grid on top of the outer one, they are actually identical
+      ! but the inner one is MPI-scattered, so we need two separate objects to store them
+      ioWRITE(*,*) "--> Setting up inner grid from outer grid"
+      ! Grid type here is always "simple" because we want to reuse the eventual random
+      ! shift from the outer grid (using two different shifts would not work)
+      CALL setup_grid("simple", S%bg, out_grid%n(1),out_grid%n(2),out_grid%n(3), &
+         in_grid, xq0=out_grid%xq0, scatter=.true.)
+      CALL prepare_q_basis(out_grid, qbasis, nconf, input%T, S, fc2)
 
-    !
-    ALLOCATE(A_out(nconf, nat3, nq))
-    ALLOCATE(inv_sqrt_A_out(nconf, nat3, nq))
-    ALLOCATE(f(3, nconf, nat3, nq))
-    ALLOCATE(g(3, nconf, nat3, nq))
-    ALLOCATE(h(3, nconf, nat3, nq))
-    ALLOCATE(t(3, nconf, nat3, nq))
-    ALLOCATE(   g_dot_h(3, nconf) )
-    ALLOCATE(   h_dot_t(3, nconf) )
-    ALLOCATE(    g_mod2(3, nconf) )
-    ALLOCATE(g_mod2_old(3, nconf) )
-    ALLOCATE(      pref(3, nconf) )
+      !
+      ALLOCATE(A_out(nconf, nat3, nq))
+      ALLOCATE(inv_sqrt_A_out(nconf, nat3, nq))
+      ALLOCATE(f(3, nconf, nat3, nq))
+      ALLOCATE(g(3, nconf, nat3, nq))
+      ALLOCATE(h(3, nconf, nat3, nq))
+      ALLOCATE(t(3, nconf, nat3, nq))
+      ALLOCATE(   g_dot_h(3, nconf) )
+      ALLOCATE(   h_dot_t(3, nconf) )
+      ALLOCATE(    g_mod2(3, nconf) )
+      ALLOCATE(g_mod2_old(3, nconf) )
+      ALLOCATE(      pref(3, nconf) )
       timer_CALL t_tkprec%stop()
-    !
-    ! Try if restart file can be read (will return false if input%restart is false):
+      !
+      ! Try if restart file can be read (will return false if input%restart is false):
       timer_CALL t_restart%start()
-    restart_ok = read_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter0, tk)
+      restart_ok = read_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter0, tk)
       timer_CALL t_restart%stop()
-    !
-    IF(.not. restart_ok) THEN
-      ! Compute A_out diagonal matrix
-    ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") &
+      !
+      IF(.not. restart_ok) THEN
+         ! Compute A_out diagonal matrix
+         ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") &
             "Computing A_out"
-        timer_CALL t_tkaout%start()
-      !CALL compute_A_out_symq(A_out, input, qbasis, out_grid, in_grid, S, fc2, fc3)
-      CALL compute_A_out(A_out, input, qbasis, out_grid, in_grid, S, fc2, fc3)
-          timer_CALL t_tkaout%stop()
+         timer_CALL t_tkaout%start()
+         !CALL compute_A_out_symq(A_out, input, qbasis, out_grid, in_grid, S, fc2, fc3)
+         CALL compute_A_out(A_out, input, qbasis, out_grid, in_grid, S, fc2, fc3)
+         timer_CALL t_tkaout%stop()
+         !
+         ! Save A_out, so we do not have to repeat it
+         timer_CALL t_restart%start()
+         CALL save_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter0, tk)
+         timer_CALL t_restart%stop()
+         !
+      ENDIF
       !
-      ! Save A_out, so we do not have to repeat it
-        timer_CALL t_restart%start()
-      CALL save_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter0, tk)
-        timer_CALL t_restart%stop()
-      !
-    ENDIF
-    !
-    ! Compute A_out^(-1/2) and A_out^-1 from A_out
-          timer_CALL t_tkprec%start()
-    CALL compute_inv_sqrt_A_out(A_out, inv_sqrt_A_out, nconf, nat3, nq)
-          timer_CALL t_tkprec%stop()
-    ! Go to the reduced variables:
-    ! \tilde{b} = A_out^(-1/2) b
-    qbasis%b = A_diag_f(inv_sqrt_A_out, qbasis%b, nconf, nat3, nq)
-    !
-    !
-    ! Bootstrap the CG algorithm, not needed when restarting except if restarting from just after A_out
-    IF(iter0 == 0) THEN
-      ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") &
-              "iter ", 0
-      ! \tilde{f0} = A_out^(1/2) f0 = A_out^(-1/2) b = \tilde{b}
-      f = qbasis%b
-      ! "tilde" label dropped from here on
-      !
-      ! Compute SMA tk = lambda f0.b
-          timer_CALL t_tkprec%start()
-      g = 0._dp
-      !
-      tk = calc_tk_gf(g, f, qbasis%b, input%T, out_grid%w, S%omega, nconf, nat3, nq)
-      ! Open files to output the SMA TK values separately
-      CALL print_tk(input, tk, "SMA TK", 10000, -1)
-          timer_CALL t_tkprec%stop()
-      !
-      ! Compute g0 = Af0 - b
-        timer_CALL t_tkain%start()
-      CALL tilde_A_times_f(f, g, inv_sqrt_A_out, input, qbasis, out_grid, in_grid, S, fc2, fc3)
-        timer_CALL t_tkain%stop()
-      !
-        timer_CALL t_tkprec%start()
-      g =  g - qbasis%b
-      !
-      ! Trivially set h0 = -g0
-      h = -g
+      ! Compute A_out^(-1/2) and A_out^-1 from A_out
+      timer_CALL t_tkprec%start()
+      CALL compute_inv_sqrt_A_out(A_out, inv_sqrt_A_out, nconf, nat3, nq)
+      timer_CALL t_tkprec%stop()
+      ! Go to the reduced variables:
+      ! \tilde{b} = A_out^(-1/2) b
+      qbasis%b = A_diag_f(inv_sqrt_A_out, qbasis%b, nconf, nat3, nq)
       !
       !
-      tk = calc_tk_gf(g, f, qbasis%b, input%T, out_grid%w, S%omega, nconf, nat3, nq)
-      CALL print_tk(input, tk, "Initial TK from 1/2(fg-fb)", 10000, 0)
-        timer_CALL t_tkprec%stop()
+      ! Bootstrap the CG algorithm, not needed when restarting except if restarting from just after A_out
+      IF(iter0 == 0) THEN
+         ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") &
+            "iter ", 0
+         ! \tilde{f0} = A_out^(1/2) f0 = A_out^(-1/2) b = \tilde{b}
+         f = qbasis%b
+         ! "tilde" label dropped from here on
+         !
+         ! Compute SMA tk = lambda f0.b
+         timer_CALL t_tkprec%start()
+         g = 0._dp
+         !
+         tk = calc_tk_gf(g, f, qbasis%b, input%T, out_grid%w, S%omega, nconf, nat3, nq)
+         ! Open files to output the SMA TK values separately
+         CALL print_tk(input, tk, "SMA TK", 10000, -1)
+         timer_CALL t_tkprec%stop()
+         !
+         ! Compute g0 = Af0 - b
+         timer_CALL t_tkain%start()
+         CALL tilde_A_times_f(f, g, inv_sqrt_A_out, input, qbasis, out_grid, in_grid, S, fc2, fc3)
+         timer_CALL t_tkain%stop()
+         !
+         timer_CALL t_tkprec%start()
+         g =  g - qbasis%b
+         !
+         ! Trivially set h0 = -g0
+         h = -g
+         !
+         !
+         tk = calc_tk_gf(g, f, qbasis%b, input%T, out_grid%w, S%omega, nconf, nat3, nq)
+         CALL print_tk(input, tk, "Initial TK from 1/2(fg-fb)", 10000, 0)
+         timer_CALL t_tkprec%stop()
+         !
+         timer_CALL t_restart%start()
+         iter0 = 1
+         CALL save_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter0, tk)
+         timer_CALL t_restart%stop()
+      ENDIF
       !
-        timer_CALL t_restart%start()
-      iter0 = 1
-      CALL save_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter0, tk)
-        timer_CALL t_restart%stop()
-    ENDIF
-    !
-    ! Compute initial variational tk0 =-\lambda (f0.g0-f0.b)
-    !ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") "iter ", 0
-    !
-    g_mod2 = qbasis_dot(g, g, nconf, nat3, nq )
-    !
-    CGP_ITERATION : &
-    DO iter = iter0,input%niter_max
-      CALL check_graceful_termination()
-      ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") "iter ", iter
-      ! t = Ah = [A_out^(-1/2) (1+A_in) A_out^(-1/2)] h
-        timer_CALL t_tkain%start()
-      CALL tilde_A_times_f(h, t, inv_sqrt_A_out, input, qbasis, out_grid, in_grid, S, fc2, fc3)
-        timer_CALL t_tkain%stop()
+      ! Compute initial variational tk0 =-\lambda (f0.g0-f0.b)
+      !ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") "iter ", 0
       !
-        timer_CALL t_tkcg%start()
-      ! Do a CG step:
-      ! f_(i+1) = f_i - (g_i.h_i / h_i.t_i) h_i
-      ! g_(i+1) = g_i - (g_i.h_i / h_i.t_i) t_i
-      g_dot_h = qbasis_dot(g, h,  nconf, nat3, nq )   ! g.h
-      h_dot_t = qbasis_dot(h, t, nconf, nat3, nq )    ! h.t
-      pref = qbasis_a_over_b(g_dot_h, h_dot_t, nconf) ! g.h/h.t
-      !f_old = f
-      f = f - qbasis_ax(pref, h, nconf, nat3, nq)
+      g_mod2 = qbasis_dot(g, g, nconf, nat3, nq )
+      !
+      CGP_ITERATION : &
+         DO iter = iter0,input%niter_max
+         CALL check_graceful_termination()
+         ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") "iter ", iter
+         ! t = Ah = [A_out^(-1/2) (1+A_in) A_out^(-1/2)] h
+         timer_CALL t_tkain%start()
+         CALL tilde_A_times_f(h, t, inv_sqrt_A_out, input, qbasis, out_grid, in_grid, S, fc2, fc3)
+         timer_CALL t_tkain%stop()
+         !
+         timer_CALL t_tkcg%start()
+         ! Do a CG step:
+         ! f_(i+1) = f_i - (g_i.h_i / h_i.t_i) h_i
+         ! g_(i+1) = g_i - (g_i.h_i / h_i.t_i) t_i
+         g_dot_h = qbasis_dot(g, h,  nconf, nat3, nq )   ! g.h
+         h_dot_t = qbasis_dot(h, t, nconf, nat3, nq )    ! h.t
+         pref = qbasis_a_over_b(g_dot_h, h_dot_t, nconf) ! g.h/h.t
+         !f_old = f
+         f = f - qbasis_ax(pref, h, nconf, nat3, nq)
 
-      g = g - qbasis_ax(pref, t, nconf, nat3, nq)
-      !
-      !In case you want to compute explicitly the gradient (i.e. for testing):
+         g = g - qbasis_ax(pref, t, nconf, nat3, nq)
+         !
+         !In case you want to compute explicitly the gradient (i.e. for testing):
 !       ALLOCATE(j(3, nconf, nat3, nq))
 !       CALL tilde_A_times_f(f, j, inv_sqrt_A_out, input, qbasis, &
 !                            out_grid, in_grid, S, fc2, fc3)
 !       j = j-qbasis%b
+         !
+         tk_old = tk
+         !tk = -\lambda (f.g-f.b)
+         tk = calc_tk_gf(g, f, qbasis%b, input%T, out_grid%w, S%omega, nconf, nat3, nq)
+         CALL print_tk(input, tk, "TK from 1/2(fg-fb)", 10000, iter)
+         ! also compute the variation of tk and check for convergence
+         WHERE(tk/=0._dp); delta_tk = (tk-tk_old)/ABS(tk)
+         ELSEWHERE;        delta_tk = 0._dp
+         END WHERE
+         CALL print_deltatk(delta_tk, input%sigma, input%T, nconf, "Delta TK (relative)")
+         conv = check_conv_tk(input%thr_tk, nconf, delta_tk)
+         !
+         IF(conv) THEN
+            ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") &
+               "Convergence achieved"
+            CALL save_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter+1, tk)
+            EXIT CGP_ITERATION
+         ENDIF
+         !
+         ! h_(i+1) = -g_(i+1) + (g_(i+1).g_(i+1)) / (g_i.g_i) h_i
+         g_mod2_old = g_mod2
+         g_mod2 = qbasis_dot(g, g, nconf, nat3, nq )
+         !
+         ! Compute the new conjugate gradient:
+         ! h_(i+1) = (g_(i+1).g_(i+1) / g_i.g_i) h_i - g_(i+1)
+         pref = qbasis_a_over_b(g_mod2, g_mod2_old, nconf)
+         h = -g + qbasis_ax(pref, h, nconf, nat3, nq)
+         timer_CALL t_tkcg%stop()
+         !
+         ! Store to file for restart
+         timer_CALL t_restart%start()
+         CALL save_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter+1, tk)
+         timer_CALL t_restart%stop()
+         !
+      ENDDO &
+         CGP_ITERATION
       !
-      tk_old = tk
-      !tk = -\lambda (f.g-f.b)
-      tk = calc_tk_gf(g, f, qbasis%b, input%T, out_grid%w, S%omega, nconf, nat3, nq)
-      CALL print_tk(input, tk, "TK from 1/2(fg-fb)", 10000, iter)
-      ! also compute the variation of tk and check for convergence
-      WHERE(tk/=0._dp); delta_tk = (tk-tk_old)/ABS(tk)
-      ELSEWHERE;        delta_tk = 0._dp
-      END WHERE
-      CALL print_deltatk(delta_tk, input%sigma, input%T, nconf, "Delta TK (relative)")
-      conv = check_conv_tk(input%thr_tk, nconf, delta_tk)
-      !
-      IF(conv) THEN
-        ioWRITE(stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") &
-                      "Convergence achieved"
-        CALL save_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter+1, tk)
-        EXIT CGP_ITERATION
+      IF(iter>input%niter_max) THEN
+         ioWRITE (stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") &
+            "Maximum number of iterations reached."
       ENDIF
       !
-      ! h_(i+1) = -g_(i+1) + (g_(i+1).g_(i+1)) / (g_i.g_i) h_i
-      g_mod2_old = g_mod2
-      g_mod2 = qbasis_dot(g, g, nconf, nat3, nq )
-      !
-      ! Compute the new conjugate gradient:
-      ! h_(i+1) = (g_(i+1).g_(i+1) / g_i.g_i) h_i - g_(i+1)
-      pref = qbasis_a_over_b(g_mod2, g_mod2_old, nconf)
-      h = -g + qbasis_ax(pref, h, nconf, nat3, nq)
-        timer_CALL t_tkcg%stop()
-      !
-      ! Store to file for restart
-        timer_CALL t_restart%start()
-      CALL save_cg_step(input, S, A_out, f, g, h, nconf, nat3, nq, iter+1, tk)
-        timer_CALL t_restart%stop()
-      !
-    ENDDO &
-    CGP_ITERATION
-    !
-    IF(iter>input%niter_max) THEN
-      ioWRITE (stdout,"(3x,'\>\^\~',40('-'),'^v^v',20('-'),'=/~/o>',/,4x,a,i4)") &
-                    "Maximum number of iterations reached."
-    ENDIF
-    !
 #ifdef timer_CALL
       ioWRITE(stdout,'("   * WALL : ",f12.4," s")') get_wall()
       CALL print_timers_header()
@@ -739,58 +740,60 @@ MODULE thermalk_program
       CALL t_mpicom%print()
       CALL t_merged%print()
 #endif
-    END SUBROUTINE TK_CG_prec
-  END MODULE thermalk_program
+   END SUBROUTINE TK_CG_prec
+END MODULE thermalk_program
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 PROGRAM thermalk
 
-  USE kinds,            ONLY : DP
-  USE thermalk_program
-!   USE environment,      ONLY : environment_start, environment_end
-!   USE mp_world,         ONLY : mp_world_start, mp_world_end, world_comm
-  USE input_fc,         ONLY : forceconst2_grid, ph_system_info
+   USE kinds,            ONLY : DP
+   USE thermalk_program
+   !   USE environment,      ONLY : environment_start, environment_end
+   !   USE mp_world,         ONLY : mp_world_start, mp_world_end, world_comm
+   USE input_fc,         ONLY : forceconst2_grid, ph_system_info
   USE q_grids,          ONLY : q_grid
-  USE fc3_interpolate,  ONLY : forceconst3
-  USE code_input,       ONLY : READ_INPUT, code_input_type
-  USE mpi_thermal,      ONLY : start_mpi, stop_mpi
-  USE nanoclock,        ONLY : init_nanoclock
-  USE more_constants,   ONLY : print_citations_linewidth
-  !
-  USE posix_signal,       ONLY : set_TERMINATE_GRACEFULLY
-  IMPLICIT NONE
-  !
-  TYPE(forceconst2_grid)     :: fc2
-  CLASS(forceconst3),POINTER :: fc3
-  TYPE(ph_system_info)       :: S
-  TYPE(code_input_type)      :: tkinput
-  TYPE(q_grid)               :: out_grid
+   USE fc3_interpolate,  ONLY : forceconst3
+   USE code_input,       ONLY : READ_INPUT, code_input_type
+   USE mpi_thermal,      ONLY : start_mpi, stop_mpi
+   USE nanoclock,        ONLY : init_nanoclock
+   USE more_constants,   ONLY : print_citations_linewidth
+   !
+   USE posix_signal,       ONLY : set_TERMINATE_GRACEFULLY
+   IMPLICIT NONE
+   !
+   TYPE(forceconst2_grid)     :: fc2
+   CLASS(forceconst3),POINTER :: fc3
+   TYPE(ph_system_info)       :: S
+   TYPE(code_input_type)      :: tkinput
+   TYPE(q_grid)               :: out_grid
 
 !   CALL mp_world_start(world_comm)
 !   CALL environment_start('TK')
-  CALL init_nanoclock()
-  CALL start_mpi()
-  CALL print_citations_linewidth()
-  CALL set_TERMINATE_GRACEFULLY() !print_timers_and_die)
+   CALL init_nanoclock()
+   CALL start_mpi()
+   CALL print_citations_linewidth()
+   CALL set_TERMINATE_GRACEFULLY() !print_timers_and_die)
 
-  ! READ_INPUT also reads force constants from disk, using subroutine READ_DATA
-  CALL READ_INPUT("TK", tkinput, out_grid, S, fc2, fc3)
-  !
-  IF(TRIM(tkinput%calculation) == "sma") THEN
-    !
-    CALL TK_SMA(tkinput, out_grid, S, fc2, fc3)
-    !
-  ELSEIF(TRIM(tkinput%calculation) == "cgp" .or. TRIM(tkinput%calculation) == "exact") THEN
-    !
-    !CALL TK_SMA(tkinput, out_grid, S, fc2, fc3)    
-    CALL TK_CG_prec(tkinput, out_grid, S, fc2, fc3)
-    !
-  ELSE
-    CALL errore("tk", "Unknown calculation type: "//TRIM(tkinput%calculation), 1)
-  ENDIF
-  !
-  IF(ionode) CALL print_citations_linewidth()
-  CALL stop_mpi()
+   ! READ_INPUT also reads force constants from disk, using subroutine READ_DATA
+   CALL READ_INPUT("TK", tkinput, out_grid, S, fc2, fc3)
+   !
+   IF(TRIM(tkinput%calculation) == "sma") THEN
+      IF(tkinput%use_symm) CALL out_grid%symmetrize(S)
+      ! CALL out_grid%scatter()
+      ! IF(tkinput%delta_approx == 'tetra') CALL tetra_init(tkinput%nk_in, S%bg, .true., .false.)
+      CALL TK_SMA(tkinput, out_grid, S, fc2, fc3)
+      !
+   ELSEIF(TRIM(tkinput%calculation) == "cgp" .or. TRIM(tkinput%calculation) == "exact") THEN
+      !
+      !CALL TK_SMA(tkinput, out_grid, S, fc2, fc3)
+      CALL TK_CG_prec(tkinput, out_grid, S, fc2, fc3)
+      !
+   ELSE
+      CALL errore("tk", "Unknown calculation type: "//TRIM(tkinput%calculation), 1)
+   ENDIF
+   !
+   IF(ionode) CALL print_citations_linewidth()
+   CALL stop_mpi()
 
 END PROGRAM thermalk
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!

--- a/thermal2/PROGRAM_tk.f90
+++ b/thermal2/PROGRAM_tk.f90
@@ -11,7 +11,7 @@ MODULE thermalk_program
    USE kinds,       ONLY : DP
    USE mpi_thermal, ONLY : ionode, mpi_bsum
    USE posix_signal,ONLY : check_graceful_termination
-   USE q_grids,            ONLY : q_grid, setup_grid, fc_info
+   USE q_grids,            ONLY : q_grid, setup_grid
    USE timers
    !
 CONTAINS

--- a/thermal2/fc3_interp.f90
+++ b/thermal2/fc3_interp.f90
@@ -7,1131 +7,1531 @@
 !
 ! Module that uses object oriented features of Fortran 2003 to deal with both
 ! regular-grid and sparse representations of Force constants in a transparent way.
-! May not compile with some less maintained compilers, should work at least with 
+! May not compile with some less maintained compilers, should work at least with
 ! gfortran, xlf, ifort and pgi compiler. Does not compile with g95.
 !
-! It is not written defensively, e.g. writing and interpolating FCs do not check 
+! It is not written defensively, e.g. writing and interpolating FCs do not check
 ! if the data has been read. May be improved in the future.
 !
 #define __PRECOMPUTE_PHASES
 #ifdef __PRECOMPUTE_PHASES
-!dir$ message "----------------------------------------------------------------------------------------------" 
-!dir$ message "Using MKL vectorized Sin and Cos implementation, this can use more memory but should be faster" 
-!dir$ message "----------------------------------------------------------------------------------------------" 
+!dir$ message "----------------------------------------------------------------------------------------------"
+!dir$ message "Using MKL vectorized Sin and Cos implementation, this can use more memory but should be faster"
+!dir$ message "----------------------------------------------------------------------------------------------"
 #endif
 !
 MODULE fc3_interpolate
-  USE kinds,            ONLY : DP
-  USE parameters,       ONLY : ntypx
-  USE mpi_thermal,      ONLY : ionode
+   USE kinds,            ONLY : DP
+   USE parameters,       ONLY : ntypx
+   USE mpi_thermal,      ONLY : ionode
 #include "mpi_thermal.h"
-  !USE input_fc,              ONLY : ph_system_info
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  ! Abstract implementation: all methods are abstract 
-  TYPE,ABSTRACT :: forceconst3
-    ! q points
-    INTEGER :: n_R = 0
-    INTEGER :: i_00 = -1 ! set to the index where both R2 and R3 are zero
-    INTEGER :: nq(3) ! initial q-point grid size (unused)
-    INTEGER,ALLOCATABLE  :: yR2(:,:), yR3(:,:) ! crystalline coords  3*n_R
-    REAL(DP),ALLOCATABLE :: xR2(:,:), xR3(:,:) ! cartesian coords    3*n_R
-    CONTAINS
+   !USE input_fc,              ONLY : ph_system_info
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   ! Abstract implementation: all methods are abstract
+   TYPE,ABSTRACT :: forceconst3
+      ! q points
+      INTEGER :: n_R = 0
+      INTEGER :: i_00 = -1 ! set to the index where both R2 and R3 are zero
+      INTEGER :: nq(3) ! initial q-point grid size (unused)
+      INTEGER,ALLOCATABLE  :: yR2(:,:), yR3(:,:) ! crystalline coords  3*n_R
+      REAL(DP),ALLOCATABLE :: xR2(:,:), xR3(:,:) ! cartesian coords    3*n_R
+   CONTAINS
+      procedure(fft_interp_sum_R2), DEFERRED :: sum_R2
       procedure(fftinterp_mat3_error),deferred :: interpolate
+      !> gradient obtained in reciprocal space, only for sparse, NOT TESTED
+      procedure(fftinterp_mat3_grad), deferred :: interpolate_grad
       procedure(fft_doubleinterp_mat3_error),deferred :: double_interpolate
       procedure :: destroy      => destroy_fc3_
       procedure(read_fc3_error),deferred :: read
       procedure(write_fc3_error),deferred :: write
       procedure(div_mass_fc3_error),deferred :: div_mass
-  END TYPE forceconst3
-  !
-  ! Interfaces to the deferred subroutines:
-  ABSTRACT INTERFACE
-  SUBROUTINE fftinterp_mat3_error(fc, xq2,xq3, nat3, D)
-    USE kinds,     ONLY : DP
-    IMPORT forceconst3 
-    CLASS(forceconst3),INTENT(in) :: fc
-    INTEGER,INTENT(in)   :: nat3
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-  END SUBROUTINE fftinterp_mat3_error
-  END INTERFACE
-  !
-  ABSTRACT INTERFACE
-  SUBROUTINE fft_doubleinterp_mat3_error(fc, xq2,xq3,xq3b, nat3, D, Db)
-    USE kinds,     ONLY : DP
-    IMPORT forceconst3 
-    CLASS(forceconst3),INTENT(in) :: fc
-    INTEGER,INTENT(in)   :: nat3
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3), xq3b(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    COMPLEX(DP),INTENT(out) :: Db(nat3, nat3, nat3)
-  END SUBROUTINE fft_doubleinterp_mat3_error
-  END INTERFACE
-  !
-  ABSTRACT INTERFACE
-  SUBROUTINE read_fc3_error(fc, filename, S)
-    USE input_fc,              ONLY : ph_system_info
-    IMPORT forceconst3 
-    CHARACTER(len=*),INTENT(in)        :: filename
-    TYPE(ph_system_info),INTENT(inout) :: S ! = System
-    CLASS(forceconst3),INTENT(inout)   :: fc
-  END SUBROUTINE read_fc3_error
-  END INTERFACE
-  !
-  ABSTRACT INTERFACE
-  SUBROUTINE write_fc3_error(fc, filename, S)
-    USE input_fc,              ONLY : ph_system_info
-    IMPORT forceconst3 
-    CHARACTER(len=*),INTENT(in)     :: filename
-    TYPE(ph_system_info),INTENT(in) :: S ! = System
-    CLASS(forceconst3),INTENT(in)   :: fc
-  END SUBROUTINE write_fc3_error
-  END INTERFACE
-  !
-  ABSTRACT INTERFACE
-  SUBROUTINE div_mass_fc3_error(fc, S)
-    USE input_fc,              ONLY : ph_system_info
-    IMPORT forceconst3 
-    CLASS(forceconst3),INTENT(inout) :: fc
-    TYPE(ph_system_info),INTENT(in)  :: S ! = System
-  END SUBROUTINE div_mass_fc3_error
-  END INTERFACE
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  !
-  ! First implementation: not regular double grid
-  TYPE,EXTENDS(forceconst3) :: grid
-    REAL(DP),ALLOCATABLE :: FC(:,:,:,:) ! 3*nat,3*nat,3*nat, n_R
-    ! Optional, imaginary part of the force constants, for testing only (should be zero)
-    REAL(DP),ALLOCATABLE :: iFC(:,:,:,:) ! 3*nat,3*nat,3*nat, n_R
-    !
-    CONTAINS
-      ! There are 2 version of the interpolation routine, that differ on the 
-      ! parallelism model via OMP, in principle they are both correct but only 
+   END TYPE forceconst3
+   !
+   TYPE :: d3_mixed
+      LOGICAL, ALLOCATABLE :: R3(:)
+      COMPLEX(DP), ALLOCATABLE :: DR3(:,:,:,:)
+      INTEGER :: minr(3), maxr(3)
+   END TYPE
+   ! Interfaces to the deferred subroutines:
+   ABSTRACT INTERFACE
+      SUBROUTINE fft_interp_sum_R2(fc, xq, nat3, Dqr)
+         USE kinds,     ONLY : DP
+         IMPORT forceconst3
+         IMPORT d3_mixed
+         CLASS(forceconst3), INTENT(IN) :: fc
+         REAL(DP), INTENT(IN) :: xq(3)
+         INTEGER, INTENT(IN) :: nat3
+         TYPE(d3_mixed), INTENT(OUT)  :: Dqr
+      END SUBROUTINE
+   END INTERFACE
+   !
+   ABSTRACT INTERFACE
+      SUBROUTINE fftinterp_mat3_error(fc, xq2,xq3, nat3, D)
+         USE kinds,     ONLY : DP
+         IMPORT forceconst3
+         CLASS(forceconst3),INTENT(in) :: fc
+         INTEGER,INTENT(in)   :: nat3
+         REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+         COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      END SUBROUTINE fftinterp_mat3_error
+   END INTERFACE
+   !
+   ABSTRACT INTERFACE
+      SUBROUTINE fftinterp_mat3_grad(fc, xq2,xq3, nat3, D, Dgrad)
+         USE kinds,     ONLY : DP
+         IMPORT forceconst3
+         CLASS(forceconst3),INTENT(in) :: fc
+         INTEGER,INTENT(in)   :: nat3
+         REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+         COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+         COMPLEX(DP),INTENT(out) :: Dgrad(nat3, nat3, nat3,3)
+      END SUBROUTINE fftinterp_mat3_grad
+   END INTERFACE
+   !
+   ABSTRACT INTERFACE
+      SUBROUTINE fft_doubleinterp_mat3_error(fc, xq2,xq3,xq3b, nat3, D, Db)
+         USE kinds,     ONLY : DP
+         IMPORT forceconst3
+         CLASS(forceconst3),INTENT(in) :: fc
+         INTEGER,INTENT(in)   :: nat3
+         REAL(DP),INTENT(in) :: xq2(3), xq3(3), xq3b(3)
+         COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+         COMPLEX(DP),INTENT(out) :: Db(nat3, nat3, nat3)
+      END SUBROUTINE fft_doubleinterp_mat3_error
+   END INTERFACE
+   !
+   ABSTRACT INTERFACE
+      SUBROUTINE read_fc3_error(fc, filename, S)
+         USE input_fc,              ONLY : ph_system_info
+         IMPORT forceconst3
+         CHARACTER(*),INTENT(in)        :: filename
+         TYPE(ph_system_info),INTENT(inout) :: S ! = System
+         CLASS(forceconst3),INTENT(inout)   :: fc
+      END SUBROUTINE read_fc3_error
+   END INTERFACE
+   !
+   ABSTRACT INTERFACE
+      SUBROUTINE write_fc3_error(fc, filename, S)
+         USE input_fc,              ONLY : ph_system_info
+         IMPORT forceconst3
+         CHARACTER(*),INTENT(in)     :: filename
+         TYPE(ph_system_info),INTENT(in) :: S ! = System
+         CLASS(forceconst3),INTENT(in)   :: fc
+      END SUBROUTINE write_fc3_error
+   END INTERFACE
+   !
+   ABSTRACT INTERFACE
+      SUBROUTINE div_mass_fc3_error(fc, S)
+         USE input_fc,              ONLY : ph_system_info
+         IMPORT forceconst3
+         CLASS(forceconst3),INTENT(inout) :: fc
+         TYPE(ph_system_info),INTENT(in)  :: S ! = System
+      END SUBROUTINE div_mass_fc3_error
+   END INTERFACE
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   !
+   ! First implementation: not regular double grid
+   TYPE,EXTENDS(forceconst3) :: grid
+      REAL(DP),ALLOCATABLE :: FC(:,:,:,:) ! 3*nat,3*nat,3*nat, n_R
+      ! Optional, imaginary part of the force constants, for testing only (should be zero)
+      REAL(DP),ALLOCATABLE :: iFC(:,:,:,:) ! 3*nat,3*nat,3*nat, n_R
+      !
+   CONTAINS
+      ! There are 2 version of the interpolation routine, that differ on the
+      ! parallelism model via OMP, in principle they are both correct but only
       ! _flat works, because of some unclear problem with the reduction of arrays
       !procedure :: interpolate  => fftinterp_mat3_grid_reduce
 #ifdef __PRECOMPUTE_PHASES
       procedure :: interpolate  => fftinterp_mat3_grid_flat_prec
+      procedure :: interpolate_grad  => fftinterp_mat3_grid_flat_prec_grad
 #else
+!DEC$ SUPPRESS ALL
       procedure :: interpolate  => fftinterp_mat3_grid_flat
+      procedure :: interpolate_grad  => fftinterp_mat3_grid_flat_grad
+!DEC$ SUPPRESS NONE
 #endif
       procedure :: double_interpolate  => fft_doubleinterp_mat3_grid_flat
       !
+      procedure :: sum_R2       => todo_sum_R2
       procedure :: destroy      => destroy_fc3_grid
       procedure :: read         => read_fc3_grid
       procedure :: write        => write_fc3_grid
       procedure :: div_mass     => div_mass_fc3_grid
-  END TYPE grid
-  INTERFACE grid
-    MODULE PROCEDURE create_fc3_grid
-  END INTERFACE
-  !
-  ! \/o\________\\\_________________________________________/^>
-  !
-  ! Second implementation: sparse grid
-  TYPE forceconst3_sparse_helper
-    REAL(DP),ALLOCATABLE :: fc(:)    ! the matrix elements
-    INTEGER,ALLOCATABLE  :: idx(:,:) ! the index 3*nat,3*nat,3*nat
-  END TYPE forceconst3_sparse_helper
-  !
-  TYPE,EXTENDS(forceconst3) :: sparse
-    INTEGER,ALLOCATABLE  :: n_terms(:) ! number of non-zero elements for each R2,R3
-    TYPE(forceconst3_sparse_helper),ALLOCATABLE :: dat(:)
-    !
-    CONTAINS
+   END TYPE grid
+   INTERFACE grid
+      MODULE PROCEDURE create_fc3_grid
+   END INTERFACE
+   !
+   ! \/o\________\\\_________________________________________/^>
+   !
+   ! Second implementation: sparse grid
+   TYPE forceconst3_sparse_helper
+      REAL(DP),ALLOCATABLE :: fc(:)    ! the matrix elements
+      INTEGER,ALLOCATABLE  :: idx(:,:) ! the index 3*nat,3*nat,3*nat
+   END TYPE forceconst3_sparse_helper
+   !
+   TYPE,EXTENDS(forceconst3) :: sparse
+      INTEGER,ALLOCATABLE  :: n_terms(:) ! number of non-zero elements for each R2,R3
+      TYPE(forceconst3_sparse_helper),ALLOCATABLE :: dat(:)
+      !
+   CONTAINS
 #ifdef __PRECOMPUTE_PHASES
       procedure :: interpolate  => fftinterp_mat3_sparse_prec
+      procedure :: interpolate_grad  => fftinterp_mat3_sparse_prec_grad
+
 #else
       procedure :: interpolate  => fftinterp_mat3_sparse
+      procedure :: interpolate_grad  => fftinterp_mat3_sparse_grad
+
 #endif
+      procedure :: sum_R2 => sum_R2_sparse
       procedure :: double_interpolate  => fft_doubleinterp_mat3_sparse_prec
       procedure :: destroy      => destroy_fc3_sparse
       procedure :: read         => read_fc3_sparse
       procedure :: write        => write_fc3_sparse
       procedure :: div_mass     => div_mass_fc3_sparse
-  END TYPE sparse
-  INTERFACE sparse
-    MODULE PROCEDURE create_fc3_sparse
-  END INTERFACE
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  !
-  ! Third implementation: always return a constant (divided by the masses?)
-  TYPE,EXTENDS(forceconst3) :: constant
-    REAL(DP) :: constant = 0._dp
-    COMPLEX(DP),ALLOCATABLE :: D(:,:,:)
-    !
-    CONTAINS
+   END TYPE sparse
+   INTERFACE sparse
+      MODULE PROCEDURE create_fc3_sparse
+   END INTERFACE
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   !
+   ! Third implementation: always return a constant (divided by the masses?)
+   TYPE,EXTENDS(forceconst3) :: constant
+      REAL(DP) :: constant = 0._dp
+      COMPLEX(DP),ALLOCATABLE :: D(:,:,:)
       !
+   CONTAINS
+      !
+      procedure :: sum_R2       => todo_sum_R2_const
       procedure :: interpolate  => fftinterp_mat3_constant
+      procedure :: interpolate_grad => fftinterp_mat3_constant_grad
       procedure :: double_interpolate  => fft_doubleinterp_mat3_constant
       procedure :: destroy      => destroy_fc3_constant
       procedure :: read         => read_fc3_constant
       procedure :: write        => write_fc3_constant
       procedure :: div_mass     => div_mass_fc3_constant
-  END TYPE constant
-  INTERFACE constant
-    MODULE PROCEDURE create_fc3_constant
-  END INTERFACE
-  ! \/o\________\\\_________________________________________/^>
-  CONTAINS
-  ! \/o\________\\\_________________________________________/^>
-  !
-  ! Returns a pointer to FC matrices, call as:
-  !    TYPE(ph_system_info),INTENT(in)   :: S
-  !    CLASS(forceconst3),POINTER :: fc
-  !     ...
-  !    fc => read_fc3("file_mat3", S)
-  ! This will read both sparse and grid files, there is room for improvement but not much.
-  !
-  FUNCTION read_fc3(filename, S) RESULT(fc)
-    USE input_fc, ONLY : read_system, ph_system_info
-    IMPLICIT NONE
-    CHARACTER(len=*),INTENT(in)          :: filename
-    TYPE(ph_system_info),INTENT(out)   :: S ! = System
-    CLASS(forceconst3),POINTER :: fc
-    !
-    INTEGER, EXTERNAL :: find_free_unit
-    INTEGER :: unit, ios
-    CHARACTER(len=32) :: buf
-    !
-    ! Scan the type of file:
-    unit = find_free_unit()
-    OPEN(unit=unit,file=filename,action='read',status='old',iostat=ios)
-    IF(ios/=0) CALL errore("read_fc3","opening '"//TRIM(filename)//"'", 1)
-    READ(unit, *) buf
-    CLOSE(unit)
-    !
-    IF(buf=="sparse") THEN
-      ALLOCATE(sparse:: fc)
-    ELSE IF(buf=="constant") THEN
-      ALLOCATE(constant::   fc)
-    ELSE
-      ALLOCATE(grid::   fc)
-    ENDIF
-    !
-    ! Use class specific read method:
-    CALL fc%read(filename, S)
-    !
-    RETURN
-    !
-  END FUNCTION read_fc3  
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  ! Placeholder creators:
-  TYPE(grid) FUNCTION create_fc3_grid()
-    RETURN
-  END FUNCTION
-  TYPE(sparse) FUNCTION create_fc3_sparse()
-    RETURN
-  END FUNCTION
-  TYPE(constant) FUNCTION create_fc3_constant()
-    RETURN
-  END FUNCTION
-  !
-  ! Convert regular-grid FCs to sparse
-  ! \/o\________\\\_________________________________________/^>
-  SUBROUTINE fc3_grid_to_sparse(nat,fc, sfc, thr)
-    !
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in) :: nat
-    TYPE(grid),INTENT(in)    :: fc
-    TYPE(sparse),INTENT(out) :: sfc
-    REAL(DP),OPTIONAL,INTENT(in) :: thr
-    !
-    REAL(DP),PARAMETER :: eps12 = 1.d-12
-    INTEGER :: iR, n_found
-    INTEGER :: na1,  na2,  na3,  j1,  j2,  j3, jn1, jn2, jn3
-    REAL(DP) :: eps
-    !
-    eps = eps12
-    IF(present(thr)) eps = thr
-    !
-    sfc%n_R  = fc%n_R
-    sfc%i_00 = fc%i_00
-    sfc%nq   = fc%nq
-    !
-    ALLOCATE(sfc%yR2(3,sfc%n_R), sfc%yR3(3,sfc%n_R))
-    ALLOCATE(sfc%xR2(3,sfc%n_R), sfc%xR3(3,sfc%n_R))
-    sfc%yR2 = fc%yR2;    sfc%yR3 = fc%yR3
-    sfc%xR2 = fc%xR2;    sfc%xR3 = fc%xR3
-    ALLOCATE(sfc%dat(sfc%n_R))
-    ALLOCATE(sfc%n_terms(sfc%n_R))
-    
-    DO iR = 1, sfc%n_R
-      sfc%n_terms(iR) = COUNT(  ABS(fc%FC(:,:,:,iR))>eps )
-      ALLOCATE(sfc%dat(iR)%idx(3,sfc%n_terms(iR)))
-      ALLOCATE(sfc%dat(iR)%fc(sfc%n_terms(iR)))
-    ENDDO
-    
-    DO iR = 1, sfc%n_R
+   END TYPE constant
+   INTERFACE constant
+      MODULE PROCEDURE create_fc3_constant
+   END INTERFACE
+   ! \/o\________\\\_________________________________________/^>
+CONTAINS
+   ! \/o\________\\\_________________________________________/^>
+   !
+   ! Returns a pointer to FC matrices, call as:
+   !    TYPE(ph_system_info),INTENT(in)   :: S
+   !    CLASS(forceconst3),POINTER :: fc
+   !     ...
+   !    fc => read_fc3("file_mat3", S)
+   ! This will read both sparse and grid files, there is room for improvement but not much.
+   !
+   SUBROUTINE todo_sum_R2(fc, xq, nat3, Dqr)
+      ! USE kinds,     ONLY : DP
+      ! IMPORT forceconst3
+      CLASS(grid), INTENT(IN)               :: fc
+      REAL(DP), INTENT(IN)                  :: xq(3)
+      INTEGER, INTENT(IN)                   :: nat3
+      TYPE(d3_mixed), INTENT(OUT)           :: Dqr
+      ! TODO
+   END SUBROUTINE
+
+   SUBROUTINE todo_sum_R2_const(fc, xq, nat3, Dqr)
+      ! USE kinds,     ONLY : DP
+      ! IMPORT forceconst3
+      CLASS(constant), INTENT(IN)               :: fc
+      REAL(DP), INTENT(IN)                  :: xq(3)
+      INTEGER, INTENT(IN)                   :: nat3
+      TYPE(d3_mixed), INTENT(OUT)           :: Dqr
+      ! TODO
+   END SUBROUTINE
+
+   FUNCTION read_fc3(filename, S) RESULT(fc)
+      USE input_fc, ONLY : read_system, ph_system_info
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(in)          :: filename
+      TYPE(ph_system_info),INTENT(out)   :: S ! = System
+      CLASS(forceconst3),POINTER :: fc
       !
-      n_found = 0
+      INTEGER, EXTERNAL :: find_free_unit
+      INTEGER :: unit, ios
+      CHARACTER(32) :: buf
       !
-      DO na3=1,nat 
-      DO na2=1,nat 
-      DO na1=1,nat
-        DO j3=1,3     
-        jn3 = j3 + (na3-1)*3
-        DO j2=1,3     
-        jn2 = j2 + (na2-1)*3
-        DO j1=1,3
-        jn1 = j1 + (na1-1)*3
-          !
-          IF(ABS(fc%FC(jn1,jn2,jn3,iR))>eps)THEN
-            n_found = n_found + 1
-            IF(n_found > sfc%n_terms(iR)) CALL errore("fc3_grid_to_sparse", "too many terms", iR)
-            sfc%dat(iR)%idx(1,n_found) = jn1
-            sfc%dat(iR)%idx(2,n_found) = jn2
-            sfc%dat(iR)%idx(3,n_found) = jn3
-            sfc%dat(iR)%FC(n_found) = fc%FC(jn1,jn2,jn3,iR)
-          ENDIF
-          !
-        ENDDO
-        ENDDO
-        ENDDO
+      ! Scan the type of file:
+      unit = find_free_unit()
+      OPEN(unit=unit,file=filename,action='read',status='old',iostat=ios)
+      IF(ios/=0) CALL errore("read_fc3","opening '"//TRIM(filename)//"'", 1)
+      READ(unit, *) buf
+      CLOSE(unit)
+      !
+      IF(buf=="sparse") THEN
+         ALLOCATE(sparse:: fc)
+      ELSE IF(buf=="constant") THEN
+         ALLOCATE(constant::   fc)
+      ELSE
+         ALLOCATE(grid::   fc)
+      ENDIF
+      !
+      ! Use class specific read method:
+      CALL fc%read(filename, S)
+      !
+      RETURN
+      !
+   END FUNCTION read_fc3
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   ! Placeholder creators:
+   TYPE(grid) FUNCTION create_fc3_grid()
+      RETURN
+   END FUNCTION
+   TYPE(sparse) FUNCTION create_fc3_sparse()
+      RETURN
+   END FUNCTION
+   TYPE(constant) FUNCTION create_fc3_constant()
+      RETURN
+   END FUNCTION
+   !
+   ! Convert regular-grid FCs to sparse
+   ! \/o\________\\\_________________________________________/^>
+   SUBROUTINE fc3_grid_to_sparse(nat,fc, sfc, thr)
+      !
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in) :: nat
+      TYPE(grid),INTENT(in)    :: fc
+      TYPE(sparse),INTENT(out) :: sfc
+      REAL(DP),OPTIONAL,INTENT(in) :: thr
+      !
+      REAL(DP),PARAMETER :: eps12 = 1.d-12
+      INTEGER :: iR, n_found
+      INTEGER :: na1,  na2,  na3,  j1,  j2,  j3, jn1, jn2, jn3
+      REAL(DP) :: eps
+      !
+      eps = eps12
+      IF(present(thr)) eps = thr
+      !
+      sfc%n_R  = fc%n_R
+      sfc%i_00 = fc%i_00
+      sfc%nq   = fc%nq
+      !
+      ALLOCATE(sfc%yR2(3,sfc%n_R), sfc%yR3(3,sfc%n_R))
+      ALLOCATE(sfc%xR2(3,sfc%n_R), sfc%xR3(3,sfc%n_R))
+      sfc%yR2 = fc%yR2;    sfc%yR3 = fc%yR3
+      sfc%xR2 = fc%xR2;    sfc%xR3 = fc%xR3
+      ALLOCATE(sfc%dat(sfc%n_R))
+      ALLOCATE(sfc%n_terms(sfc%n_R))
+
+      DO iR = 1, sfc%n_R
+         sfc%n_terms(iR) = COUNT(  ABS(fc%FC(:,:,:,iR))>eps )
+         ALLOCATE(sfc%dat(iR)%idx(3,sfc%n_terms(iR)))
+         ALLOCATE(sfc%dat(iR)%fc(sfc%n_terms(iR)))
       ENDDO
-      ENDDO
+
+      DO iR = 1, sfc%n_R
+         !
+         n_found = 0
+         !
+         DO na3=1,nat
+            DO na2=1,nat
+               DO na1=1,nat
+                  DO j3=1,3
+                     jn3 = j3 + (na3-1)*3
+                     DO j2=1,3
+                        jn2 = j2 + (na2-1)*3
+                        DO j1=1,3
+                           jn1 = j1 + (na1-1)*3
+                           !
+                           IF(ABS(fc%FC(jn1,jn2,jn3,iR))>eps)THEN
+                              n_found = n_found + 1
+                              IF(n_found > sfc%n_terms(iR)) CALL errore("fc3_grid_to_sparse", "too many terms", iR)
+                              sfc%dat(iR)%idx(1,n_found) = jn1
+                              sfc%dat(iR)%idx(2,n_found) = jn2
+                              sfc%dat(iR)%idx(3,n_found) = jn3
+                              sfc%dat(iR)%FC(n_found) = fc%FC(jn1,jn2,jn3,iR)
+                           ENDIF
+                           !
+                        ENDDO
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
+         ENDDO
+         !
+         IF(n_found /= sfc%n_terms(iR)) CALL errore("fc3_grid_to_sparse", "wrong number of terms", iR)
+         !
       ENDDO
       !
-      IF(n_found /= sfc%n_terms(iR)) CALL errore("fc3_grid_to_sparse", "wrong number of terms", iR)
+   END SUBROUTINE fc3_grid_to_sparse
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_grid_reduce(fc, xq2,xq3, nat3, D)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
       !
-    ENDDO
-    !
-  END SUBROUTINE fc3_grid_to_sparse
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fftinterp_mat3_grid_reduce(fc, xq2,xq3, nat3, D)
-    USE constants, ONLY : tpi
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(grid),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    !
-    REAL(DP) :: arg
-    COMPLEX(DP) :: phase
-    INTEGER :: i, a,b,c
-    !
-    D = (0._dp, 0._dp)
-    !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(grid),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      !
+      REAL(DP) :: arg
+      COMPLEX(DP) :: phase
+      INTEGER :: i, a,b,c
+      !
+      D = (0._dp, 0._dp)
+      !
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,arg,phase) REDUCTION(+: D)
-    DO i = 1, fc%n_R
-      arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
-      phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
-      D(:,:,:) = D(:,:,:) + phase * fc%fc(:,:,:, i)
-    END DO
+      DO i = 1, fc%n_R
+         arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+         D(:,:,:) = D(:,:,:) + phase * fc%fc(:,:,:, i)
+      END DO
 !$OMP END PARALLEL DO
-  END SUBROUTINE fftinterp_mat3_grid_reduce
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fftinterp_mat3_grid_flat(fc, xq2,xq3, nat3, D)
-    USE constants, ONLY : tpi
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(grid),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    !
-    REAL(DP) :: arg
-    COMPLEX(DP) :: phase
-    INTEGER :: i, a,b,c
-    !
-    D = (0._dp, 0._dp)
-    !
+   END SUBROUTINE fftinterp_mat3_grid_reduce
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_grid_flat(fc, xq2,xq3, nat3, D)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(grid),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      !
+      REAL(DP) :: arg
+      COMPLEX(DP) :: phase
+      INTEGER :: i, a,b,c
+      !
+      D = (0._dp, 0._dp)
+      !
 !$OMP PARALLEL DEFAULT(SHARED) PRIVATE(a,b,c)
-    DO i = 1, fc%n_R
-      arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
-      phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+      DO i = 1, fc%n_R
+         arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
 !$OMP DO COLLAPSE(3)
-      DO c = 1,nat3
-      DO b = 1,nat3
-      DO a = 1,nat3
-        D(a,b,c) = D(a,b,c) + phase * fc%fc(a,b,c, i)
-      ENDDO
-      ENDDO
-      ENDDO
-!$OMP END DO      
-    END DO
+         DO c = 1,nat3
+            DO b = 1,nat3
+               DO a = 1,nat3
+                  D(a,b,c) = D(a,b,c) + phase * fc%fc(a,b,c, i)
+               ENDDO
+            ENDDO
+         ENDDO
+!$OMP END DO
+      END DO
 !$OMP END PARALLEL
-  END SUBROUTINE fftinterp_mat3_grid_flat
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fftinterp_mat3_grid_flat_prec(fc, xq2,xq3, nat3, D)
-    USE constants, ONLY : tpi
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(grid),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    !
-    INTEGER :: i, a,b,c
-    REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
-    COMPLEX(DP) :: vphase(fc%n_R)
-    !
-    D = (0._dp, 0._dp)
-    !
-    ! Pre-compute phase, use vectorized MKL subroutines if available
-    FORALL(i=1:fc%n_R) varg(i) =  tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+   END SUBROUTINE fftinterp_mat3_grid_flat
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_grid_flat_prec(fc, xq2,xq3, nat3, D)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(grid),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      !
+      INTEGER :: i, a,b,c
+      REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
+      COMPLEX(DP) :: vphase(fc%n_R)
+      !
+      D = (0._dp, 0._dp)
+      !
+      ! Pre-compute phase, use vectorized MKL subroutines if available
+      FORALL(i=1:fc%n_R) varg(i) =  tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
 #if defined(__INTEL) && defined(__HASVTRIG)
 !dir$ message "Using MKL vectorized Sin and Cos implementation, if this does not compile, remove -D__HASVTRIG from Makefile"
-    CALL vdCos(fc%n_R, varg, vcos)
-    CALL vdSin(fc%n_R, varg, vsin)
+      CALL vdCos(fc%n_R, varg, vcos)
+      CALL vdSin(fc%n_R, varg, vsin)
 #else
-    vcos = DCOS(varg)
-    vsin = DSIN(varg)
+      vcos = DCOS(varg)
+      vsin = DSIN(varg)
 #endif
-    vphase =  CMPLX( vcos, -vsin, kind=DP  )
-    !
-! ==================== with imaginary part, only for testing during qq2rr    
-    IMAGINARY: &
-    IF(allocated(fc%ifc))THEN
+      vphase =  CMPLX( vcos, -vsin, kind=DP  )
+      !
+! ==================== with imaginary part, only for testing during qq2rr
+      IMAGINARY: &
+         IF(allocated(fc%ifc))THEN
 !$OMP PARALLEL DEFAULT(SHARED) PRIVATE(a,b,c)
-    DO i = 1, fc%n_R
-      !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+         DO i = 1, fc%n_R
+            !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
 !$OMP DO COLLAPSE(3)
-      DO c = 1,nat3
-      DO b = 1,nat3
-      DO a = 1,nat3
-        D(a,b,c) = D(a,b,c) + vphase(i) * CMPLX(fc%fc(a,b,c, i), fc%ifc(a,b,c, i), kind=DP)
-      ENDDO
-      ENDDO
-      ENDDO
-!$OMP END DO      
-    END DO
+            DO c = 1,nat3
+               DO b = 1,nat3
+                  DO a = 1,nat3
+                     D(a,b,c) = D(a,b,c) + vphase(i) * CMPLX(fc%fc(a,b,c, i), fc%ifc(a,b,c, i), kind=DP)
+                  ENDDO
+               ENDDO
+            ENDDO
+!$OMP END DO
+         END DO
 !$OMP END PARALLEL
 ! ==================== without imaginary part
-   ELSE IMAGINARY
+      ELSE IMAGINARY
 !$OMP PARALLEL DEFAULT(SHARED) PRIVATE(a,b,c)
-    DO i = 1, fc%n_R
-      !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+         DO i = 1, fc%n_R
+            !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
 !$OMP DO COLLAPSE(3)
-      DO c = 1,nat3
-      DO b = 1,nat3
-      DO a = 1,nat3
-        D(a,b,c) = D(a,b,c) + vphase(i) * fc%fc(a,b,c, i)
-      ENDDO
-      ENDDO
-      ENDDO
-!$OMP END DO      
-    END DO
+            DO c = 1,nat3
+               DO b = 1,nat3
+                  DO a = 1,nat3
+                     D(a,b,c) = D(a,b,c) + vphase(i) * fc%fc(a,b,c, i)
+                  ENDDO
+               ENDDO
+            ENDDO
+!$OMP END DO
+         END DO
 !$OMP END PARALLEL
-    ENDIF &
-    IMAGINARY
+      ENDIF &
+         IMAGINARY
 ! ==================== without imaginary part
-  END SUBROUTINE fftinterp_mat3_grid_flat_prec
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fft_doubleinterp_mat3_grid_flat(fc, xq2,xq3,xq3b, nat3, D, Db)
-    USE constants, ONLY : tpi
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(grid),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3), xq3b(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    COMPLEX(DP),INTENT(out) :: Db(nat3, nat3, nat3)
-    !
-    REAL(DP) :: arg1, arg2
-    COMPLEX(DP) :: phase1, phase2
-    INTEGER :: i, a,b,c
-    !
-    D  = (0._dp, 0._dp)
-    Db = (0._dp, 0._dp)
-    !
+   END SUBROUTINE fftinterp_mat3_grid_flat_prec
+
+   SUBROUTINE fftinterp_mat3_grid_flat_grad(fc, xq2,xq3, nat3, D, Dgrad)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(grid),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      COMPLEX(DP),INTENT(out) :: Dgrad(nat3, nat3, nat3,3)
+
+      !
+      REAL(DP) :: arg, cosine, sine
+      INTEGER :: i, a,b,c
+      !
+      D = (0._dp, 0._dp)
+      !
 !$OMP PARALLEL DEFAULT(SHARED) PRIVATE(a,b,c)
-    DO i = 1, fc%n_R
-      arg1 = tpi *  SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
-      phase1 = CMPLX(Cos(arg1),-Sin(arg1), kind=DP)
-      arg2 = tpi * SUM(-xq2(:)*fc%xR2(:,i) + xq3b(:)*fc%xR3(:,i))
-      phase2 = CMPLX(Cos(arg2),-Sin(arg2), kind=DP)
+      DO i = 1, fc%n_R
+         arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         cosine = Cos(arg)
+         sine = Sin(arg)
 !$OMP DO COLLAPSE(3)
-      DO c = 1,nat3
-      DO b = 1,nat3
-      DO a = 1,nat3
-        D(a,b,c)  = D(a,b,c)  + phase1 * fc%fc(a,b,c, i)
-        Db(a,b,c) = Db(a,b,c) + phase2 * fc%fc(a,b,c, i)
-      ENDDO
-      ENDDO
-      ENDDO
-!$OMP END DO      
-    END DO
+         DO c = 1,nat3
+            DO b = 1,nat3
+               DO a = 1,nat3
+                  D(a,b,c) = D(a,b,c) + CMPLX(cosine, -sine, kind=DP) * fc%fc(a,b,c, i)
+                  Dgrad(a,b,c,:) = Dgrad(a,b,c,:) + (fc%xR2(:,i) - fc%xR3(:,i)) * &
+                     CMPLX(sine, cosine, kind=DP) * fc%fc(a,b,c, i)
+               ENDDO
+            ENDDO
+         ENDDO
+!$OMP END DO
+      END DO
 !$OMP END PARALLEL
-  END SUBROUTINE fft_doubleinterp_mat3_grid_flat
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fftinterp_mat3_sparse(fc, xq2,xq3, nat3, D)
-    USE constants, ONLY : tpi
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(sparse),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    !
-    REAL(DP) :: arg
-    COMPLEX(DP) :: phase
-    INTEGER :: i,j
-    !
-    D = (0._dp, 0._dp)
-    !
+   END SUBROUTINE fftinterp_mat3_grid_flat_grad
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_grid_flat_prec_grad(fc, xq2,xq3, nat3, D, Dgrad)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(grid),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      COMPLEX(DP),INTENT(out) :: Dgrad(nat3, nat3, nat3,3)
+
+      !
+      INTEGER :: i, a,b,c
+      REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
+      COMPLEX(DP) :: vphase(fc%n_R), vphaseR(fc%n_R)
+      !
+      D = (0._dp, 0._dp)
+      !
+      ! Pre-compute phase, use vectorized MKL subroutines if available
+      FORALL(i=1:fc%n_R) varg(i) =  tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+#if defined(__INTEL) && defined(__HASVTRIG)
+!dir$ message "Using MKL vectorized Sin and Cos implementation, if this does not compile, remove -D__HASVTRIG from Makefile"
+      CALL vdCos(fc%n_R, varg, vcos)
+      CALL vdSin(fc%n_R, varg, vsin)
+#else
+      vcos = DCOS(varg)
+      vsin = DSIN(varg)
+#endif
+      vphase =  CMPLX( vcos, -vsin, kind=DP  )
+      vphaseR = CMPLX( vsin, vcos, kind=DP )
+      !
+! ==================== with imaginary part, only for testing during qq2rr
+      IMAGINARY: &
+         IF(allocated(fc%ifc))THEN
+!$OMP PARALLEL DEFAULT(SHARED) PRIVATE(a,b,c)
+         DO i = 1, fc%n_R
+            !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+!$OMP DO COLLAPSE(3)
+            DO c = 1,nat3
+               DO b = 1,nat3
+                  DO a = 1,nat3
+                     D(a,b,c) = D(a,b,c) + vphase(i) * CMPLX(fc%fc(a,b,c, i), fc%ifc(a,b,c, i), kind=DP)
+                  ENDDO
+               ENDDO
+            ENDDO
+!$OMP END DO
+         END DO
+!$OMP END PARALLEL
+! ==================== without imaginary part
+      ELSE IMAGINARY
+!$OMP PARALLEL DEFAULT(SHARED) PRIVATE(a,b,c)
+         DO i = 1, fc%n_R
+            !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+!$OMP DO COLLAPSE(3)
+            DO c = 1,nat3
+               DO b = 1,nat3
+                  DO a = 1,nat3
+                     D(a,b,c) = D(a,b,c) + vphase(i) * fc%fc(a,b,c, i)
+                     Dgrad(a,b,c,:) = Dgrad(a,b,c,:) + (fc%xR2(:,i) - fc%xR3(:,i)) * vphaseR(i) * fc%fc(a,b,c, i)
+                  ENDDO
+               ENDDO
+            ENDDO
+!$OMP END DO
+         END DO
+!$OMP END PARALLEL
+      ENDIF &
+         IMAGINARY
+! ==================== without imaginary part
+   END SUBROUTINE fftinterp_mat3_grid_flat_prec_grad
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fft_doubleinterp_mat3_grid_flat(fc, xq2,xq3,xq3b, nat3, D, Db)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(grid),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3), xq3b(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      COMPLEX(DP),INTENT(out) :: Db(nat3, nat3, nat3)
+      !
+      REAL(DP) :: arg1, arg2
+      COMPLEX(DP) :: phase1, phase2
+      INTEGER :: i, a,b,c
+      !
+      D  = (0._dp, 0._dp)
+      Db = (0._dp, 0._dp)
+      !
+!$OMP PARALLEL DEFAULT(SHARED) PRIVATE(a,b,c)
+      DO i = 1, fc%n_R
+         arg1 = tpi *  SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         phase1 = CMPLX(Cos(arg1),-Sin(arg1), kind=DP)
+         arg2 = tpi * SUM(-xq2(:)*fc%xR2(:,i) + xq3b(:)*fc%xR3(:,i))
+         phase2 = CMPLX(Cos(arg2),-Sin(arg2), kind=DP)
+!$OMP DO COLLAPSE(3)
+         DO c = 1,nat3
+            DO b = 1,nat3
+               DO a = 1,nat3
+                  D(a,b,c)  = D(a,b,c)  + phase1 * fc%fc(a,b,c, i)
+                  Db(a,b,c) = Db(a,b,c) + phase2 * fc%fc(a,b,c, i)
+               ENDDO
+            ENDDO
+         ENDDO
+!$OMP END DO
+      END DO
+!$OMP END PARALLEL
+   END SUBROUTINE fft_doubleinterp_mat3_grid_flat
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_sparse(fc, xq2,xq3, nat3, D)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(sparse),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      !
+      REAL(DP) :: arg
+      COMPLEX(DP) :: phase
+      INTEGER :: i,j
+      !
+      D = (0._dp, 0._dp)
+      !
 !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j,arg,phase) REDUCTION(+: D)
-    DO i = 1, fc%n_R
-      arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
-      phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
-      DO j = 1, fc%n_terms(i)
-        D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
-          = D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
-            + phase * fc%dat(i)%fc(j)
-      ENDDO
-    END DO
+      DO i = 1, fc%n_R
+         arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+         DO j = 1, fc%n_terms(i)
+            D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               = D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               + phase * fc%dat(i)%fc(j)
+         ENDDO
+      END DO
 !$OMP END PARALLEL DO
-  END SUBROUTINE fftinterp_mat3_sparse
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fftinterp_mat3_sparse_prec(fc, xq2,xq3, nat3, D)
-    USE constants, ONLY : tpi
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(sparse),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    !
-    INTEGER :: i,j
-    REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
-    COMPLEX(DP) :: vphase(fc%n_R)
-    !
-    D = (0._dp, 0._dp)
-    !
-    ! Pre-compute phase to use the vectorized MKL subroutines
-    FORALL(i=1:fc%n_R) varg(i) =  tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
-#if defined(__INTEL) && defined(__HASVTRIG)
-!dir$ message "Using MKL vectorized Sin and Cos implementation, if this does not compile, remove -D__HASVTRIG from Makefile"
-    CALL vdCos(fc%n_R, varg, vcos)
-    CALL vdSin(fc%n_R, varg, vsin)
-#else
-    vcos = DCOS(varg)
-    vsin = DSIN(varg)
-#endif
-    vphase =  CMPLX( vcos, -vsin, kind=DP  )
-    !    !
-    !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j) REDUCTION(+: D)
-    !/!$ACC DATA COPYIN(fc%dat, fc%idx, vphase) COPY(D)
-    DO i = 1, fc%n_R
-      !arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
-      !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
-      DO j = 1, fc%n_terms(i)
-        D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
-          = D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
-            + vphase(i) * fc%dat(i)%fc(j)
+   END SUBROUTINE fftinterp_mat3_sparse
+   !
+
+   SUBROUTINE sum_R2_sparse(fc, xq, nat3, Dqr)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      CLASS(sparse), INTENT(IN)             :: fc
+      REAL(DP), INTENT(IN)                  :: xq(3)
+      INTEGER, INTENT(IN)                   :: nat3
+      TYPE(d3_mixed), INTENT(OUT)           :: Dqr
+      !
+      INTEGER :: i,j, index3(3), iR3, nr, limits(3)
+      REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
+      COMPLEX(DP) :: vphase(fc%n_R)
+      !
+      DO i = 1, 3
+         Dqr%minr(i) = MINVAL(fc%yR2(i,:))
+         Dqr%maxr(i) = MAXVAL(fc%yR2(i,:))
       ENDDO
-    END DO
-    !/!$ACC END DATA
-    !$OMP END PARALLEL DO
-  END SUBROUTINE fftinterp_mat3_sparse_prec
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fft_doubleinterp_mat3_sparse_prec(fc, xq2,xq3,xq3b, nat3, D, Db)
-    USE constants, ONLY : tpi
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(sparse),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3), xq3b(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    COMPLEX(DP),INTENT(out) :: Db(nat3, nat3, nat3)
-    !
-    INTEGER :: i,j
-    REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
-    REAL(DP) :: vargb(fc%n_R), vcosb(fc%n_R), vsinb(fc%n_R)
-    COMPLEX(DP) :: vphase(fc%n_R)
-    COMPLEX(DP) :: vphaseb(fc%n_R)
-    !
-    D  = (0._dp, 0._dp)
-    Db = (0._dp, 0._dp)
-    !
-    ! Pre-compute phase to use the vectorized MKL subroutines
-    FORALL(i=1:fc%n_R) varg(i)  =  tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
-    FORALL(i=1:fc%n_R) vargb(i) =  tpi * SUM(-xq2(:)*fc%xR2(:,i) + xq3b(:)*fc%xR3(:,i))
+      limits = Dqr%maxr - Dqr%minr + 1
+      nr = PRODUCT(limits)
+      ALLOCATE(Dqr%R3(nr), Dqr%DR3(nat3, nat3, nat3, nr))
+      Dqr%DR3 = (0._dp, 0._dp)
+      Dqr%R3 = .false.
+      !
+      ! Pre-compute phase to use the vectorized MKL subroutines
+      FORALL(i=1:fc%n_R) varg(i) =  tpi * SUM(xq(:)*fc%xR2(:,i))
+#if defined(__INTEL) && defined(__HASVTRIG)
+      !dir$ message "Using MKL vectorized Sin and Cos implementation, if this does not compile, remove -D__HASVTRIG from Makefile"
+      CALL vdCos(fc%n_R, varg, vcos)
+      CALL vdSin(fc%n_R, varg, vsin)
+#else
+      vcos = DCOS(varg)
+      vsin = DSIN(varg)
+#endif
+      vphase =  CMPLX( vcos, -vsin, kind=DP  )
+      !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j) REDUCTION(+: DR3)
+      !/!$ACC DATA COPYIN(fc%dat, fc%idx, vphase) COPY(DR3)
+      DO i = 1, fc%n_R
+         !arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+         DO j = 1, fc%n_terms(i)
+            index3 = fc%yR3(:,i) - Dqr%minr
+            iR3 = index3(1)*limits(2)*limits(3) + index3(2)*limits(3) + index3(3) + 1
+            Dqr%R3(iR3) = .true.
+            Dqr%DR3(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j),iR3) &
+               = Dqr%DR3(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j),iR3) &
+               + vphase(i) * fc%dat(i)%fc(j)
+         ENDDO
+      END DO
+      !/!$ACC END DATA
+      !$OMP END PARALLEL DO
+   END SUBROUTINE
+
+   SUBROUTINE sum_R3(S, xq, Dqr, D)
+      use constants, only : tpi
+      use ph_system, only : ph_system_info
+      TYPE(ph_system_info) :: S
+      REAL(DP), INTENT(IN) :: xq(3)
+      TYPE(d3_mixed), INTENT(IN)           :: Dqr
+      COMPLEX(DP),INTENT(OUT) :: D(S%nat3, S%nat3, S%nat3)
+      !
+      INTEGER :: irx, iry, irz, ir
+      REAL(DP) :: xR3(3), arg
+      EXTERNAL :: cryst_to_cart
+      !
+      D = (0._dp, 0._dp)
+
+      ir = 0
+      DO irx = Dqr%minr(1), Dqr%maxr(1)
+         DO iry = Dqr%minr(2), Dqr%maxr(2)
+            DO irz = Dqr%minr(3), Dqr%maxr(3)
+               ir = ir + 1
+               IF( .not. Dqr%R3(ir)) CYCLE
+               xR3 = REAL((/irx, iry, irz/), kind=DP)
+               CALL cryst_to_cart(1, xR3, S%at, 1)
+               arg = tpi * DOT_PRODUCT(xq, xR3)
+               D = D + Dqr%DR3(:,:,:,ir) * CMPLX( COS(arg), -SIN(arg), kind=DP  )
+            END DO
+         END DO
+      END DO
+   END SUBROUTINE
+
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_sparse_prec(fc, xq2,xq3, nat3, D)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(sparse),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      !
+      INTEGER :: i,j
+      REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
+      COMPLEX(DP) :: vphase(fc%n_R)
+      !
+      D = (0._dp, 0._dp)
+      !
+      ! Pre-compute phase to use the vectorized MKL subroutines
+      FORALL(i=1:fc%n_R) varg(i) =  tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
 #if defined(__INTEL) && defined(__HASVTRIG)
 !dir$ message "Using MKL vectorized Sin and Cos implementation, if this does not compile, remove -D__HASVTRIG from Makefile"
-    CALL vdCos(fc%n_R, varg, vcos)
-    CALL vdSin(fc%n_R, varg, vsin)
-    CALL vdCos(fc%n_R, vargb, vcosb)
-    CALL vdSin(fc%n_R, vargb, vsinb)
+      CALL vdCos(fc%n_R, varg, vcos)
+      CALL vdSin(fc%n_R, varg, vsin)
 #else
-    vcos = DCOS(varg)
-    vsin = DSIN(varg)
-    vcosb = DCOS(vargb)
-    vsinb = DSIN(vargb)
+      vcos = DCOS(varg)
+      vsin = DSIN(varg)
 #endif
-    vphase =  CMPLX( vcos, -vsin, kind=DP  )
-    vphaseb =  CMPLX( vcos, -vsin, kind=DP  )
-    !    !
+      vphase =  CMPLX( vcos, -vsin, kind=DP  )
+      !    !
+      !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j) REDUCTION(+: D)
+      !/!$ACC DATA COPYIN(fc%dat, fc%idx, vphase) COPY(D)
+      DO i = 1, fc%n_R
+         !arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+         DO j = 1, fc%n_terms(i)
+            D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               = D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               + vphase(i) * fc%dat(i)%fc(j)
+         ENDDO
+      END DO
+      !/!$ACC END DATA
+      !$OMP END PARALLEL DO
+   END SUBROUTINE fftinterp_mat3_sparse_prec
+
+   SUBROUTINE fftinterp_mat3_sparse_grad(fc, xq2,xq3, nat3, D, Dgrad)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(sparse),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      COMPLEX(DP),INTENT(out) :: Dgrad(nat3, nat3, nat3,3)
+
+      !
+      REAL(DP) :: arg, cosine, sine
+      INTEGER :: i,j
+      !
+      D = (0._dp, 0._dp)
+      !
+!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j,arg,phase) REDUCTION(+: D)
+      DO i = 1, fc%n_R
+         arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         cosine = Cos(arg)
+         sine = Sin(arg)
+         DO j = 1, fc%n_terms(i)
+            D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               = D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               + CMPLX(cosine, -sine, kind=DP) * fc%dat(i)%fc(j)
+            Dgrad(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j),:) &
+               = Dgrad(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j),:) &
+               + (fc%xR2(:,i) - fc%xR3(:,i)) * CMPLX(sine,  cosine, kind=DP) * fc%dat(i)%fc(j)
+         ENDDO
+      END DO
+!$OMP END PARALLEL DO
+   END SUBROUTINE fftinterp_mat3_sparse_grad
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_sparse_prec_grad(fc, xq2,xq3, nat3, D, Dgrad)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(sparse),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      COMPLEX(DP),INTENT(out) :: Dgrad(nat3, nat3, nat3,3)
+
+
+      !
+      INTEGER :: i,j
+      REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
+      COMPLEX(DP) :: vphase(fc%n_R), vphaseR(fc%n_R)
+      !
+      D = (0._dp, 0._dp)
+      !
+      ! Pre-compute phase to use the vectorized MKL subroutines
+      FORALL(i=1:fc%n_R) varg(i) =  tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+#if defined(__INTEL) && defined(__HASVTRIG)
+!dir$ message "Using MKL vectorized Sin and Cos implementation, if this does not compile, remove -D__HASVTRIG from Makefile"
+      CALL vdCos(fc%n_R, varg, vcos)
+      CALL vdSin(fc%n_R, varg, vsin)
+#else
+      vcos = DCOS(varg)
+      vsin = DSIN(varg)
+#endif
+      vphase =  CMPLX( vcos, -vsin, kind=DP  )
+      vphaseR = CMPLX( vsin, vcos, kind=DP  )
+      !    !
+      !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j) REDUCTION(+: D)
+      !/!$ACC DATA COPYIN(fc%dat, fc%idx, vphase) COPY(D)
+      DO i = 1, fc%n_R
+         !arg = tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+         !phase = CMPLX(Cos(arg),-Sin(arg), kind=DP)
+         DO j = 1, fc%n_terms(i)
+            D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               = D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               + vphase(i) * fc%dat(i)%fc(j)
+            Dgrad(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j),:) &
+               = Dgrad(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j),:) &
+               + (fc%xR2(:,i) - fc%xR3(:,i)) * vphaseR(i) * fc%dat(i)%fc(j)
+         ENDDO
+      END DO
+      !/!$ACC END DATA
+      !$OMP END PARALLEL DO
+   END SUBROUTINE fftinterp_mat3_sparse_prec_grad
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fft_doubleinterp_mat3_sparse_prec(fc, xq2,xq3,xq3b, nat3, D, Db)
+      USE constants, ONLY : tpi
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(sparse),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3), xq3b(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      COMPLEX(DP),INTENT(out) :: Db(nat3, nat3, nat3)
+      !
+      INTEGER :: i,j
+      REAL(DP) :: varg(fc%n_R), vcos(fc%n_R), vsin(fc%n_R)
+      REAL(DP) :: vargb(fc%n_R), vcosb(fc%n_R), vsinb(fc%n_R)
+      COMPLEX(DP) :: vphase(fc%n_R)
+      COMPLEX(DP) :: vphaseb(fc%n_R)
+      !
+      D  = (0._dp, 0._dp)
+      Db = (0._dp, 0._dp)
+      !
+      ! Pre-compute phase to use the vectorized MKL subroutines
+      FORALL(i=1:fc%n_R) varg(i)  =  tpi * SUM(xq2(:)*fc%xR2(:,i) + xq3(:)*fc%xR3(:,i))
+      FORALL(i=1:fc%n_R) vargb(i) =  tpi * SUM(-xq2(:)*fc%xR2(:,i) + xq3b(:)*fc%xR3(:,i))
+#if defined(__INTEL) && defined(__HASVTRIG)
+!dir$ message "Using MKL vectorized Sin and Cos implementation, if this does not compile, remove -D__HASVTRIG from Makefile"
+      CALL vdCos(fc%n_R, varg, vcos)
+      CALL vdSin(fc%n_R, varg, vsin)
+      CALL vdCos(fc%n_R, vargb, vcosb)
+      CALL vdSin(fc%n_R, vargb, vsinb)
+#else
+      vcos = DCOS(varg)
+      vsin = DSIN(varg)
+      vcosb = DCOS(vargb)
+      vsinb = DSIN(vargb)
+#endif
+      vphase =  CMPLX( vcos, -vsin, kind=DP  )
+      vphaseb =  CMPLX( vcos, -vsin, kind=DP  )
+      !    !
 !
-    !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j) REDUCTION(+: D)
-    DO i = 1, fc%n_R
-      DO j = 1, fc%n_terms(i)
-        D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
-          = D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
-            + vphase(i) * fc%dat(i)%fc(j)
-            
-        Db(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
-          = Db(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
-            + vphaseb(i) * fc%dat(i)%fc(j)
-      ENDDO
-    END DO
-    !$OMP END PARALLEL DO
-  END SUBROUTINE fft_doubleinterp_mat3_sparse_prec
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE read_fc3_sparse(fc, filename, S)
-    USE input_fc, ONLY : read_system, ph_system_info
-    IMPLICIT NONE
-    CHARACTER(len=*),INTENT(in)          :: filename
-    TYPE(ph_system_info),INTENT(inout)   :: S ! = System
-    CLASS(sparse),INTENT(inout) :: fc
-    !
-    CHARACTER(len=13),PARAMETER :: sub = "read_fc3_sparse"
-    !
-    INTEGER :: unit, ios
-    INTEGER, EXTERNAL :: find_free_unit
-    CHARACTER(len=32) :: buf
-    CHARACTER(len=6) :: dummy
-    REAL(DP) :: factor
-    !
-    INTEGER :: i, j
-    !
-    unit = find_free_unit()
-    OPEN(unit=unit,file=filename,action='read',status='old',iostat=ios)
-    IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
-    !
-    READ(unit, '(a32)') buf
-    IF(buf(1:6)/="sparse") CALL errore(sub, "cannot read this format", 1)
-    READ(buf, *, iostat=ios) dummy, factor
-    IF(ios/=0) factor = 1._dp
-    IF(factor/=1._dp .and. ionode) WRITE(stdout, *) "WARNING! rescaling D3", factor
-    !
-    ioWRITE(stdout,*) "** Reading sparse FC3 file ", TRIM(filename)
-    CALL read_system(unit, S)
-    !
-    READ(unit, *) fc%nq
-    READ(unit, *) fc%n_R
-    ioWRITE(stdout,*) "   Original FC3 grid:", fc%nq
-    ioWRITE(stdout,*) "   Number of R:      ", fc%n_R
-    !
-    ALLOCATE(fc%n_terms(fc%n_R))
-    ALLOCATE(fc%yR2(3,fc%n_R), fc%yR3(3,fc%n_R))
-    DO i = 1,fc%n_R
-      READ(unit, *) fc%n_terms(i),  fc%yR2(:,i), fc%yR3(:,i)
-    ENDDO
-    !
-    ALLOCATE(fc%dat(fc%n_R))
-    !
-    DO i = 1, fc%n_R
+      !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j) REDUCTION(+: D)
+      DO i = 1, fc%n_R
+         DO j = 1, fc%n_terms(i)
+            D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               = D(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               + vphase(i) * fc%dat(i)%fc(j)
+
+            Db(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               = Db(fc%dat(i)%idx(1,j),fc%dat(i)%idx(2,j),fc%dat(i)%idx(3,j)) &
+               + vphaseb(i) * fc%dat(i)%fc(j)
+         ENDDO
+      END DO
+      !$OMP END PARALLEL DO
+   END SUBROUTINE fft_doubleinterp_mat3_sparse_prec
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE read_fc3_sparse(fc, filename, S)
+      USE input_fc, ONLY : read_system, ph_system_info
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(in)          :: filename
+      TYPE(ph_system_info),INTENT(inout)   :: S ! = System
+      CLASS(sparse),INTENT(inout) :: fc
       !
-      ALLOCATE(fc%dat(i)%idx(3,fc%n_terms(i)))
-      ALLOCATE(fc%dat(i)%fc(fc%n_terms(i)))
+      CHARACTER(13),PARAMETER :: sub = "read_fc3_sparse"
       !
-      DO j = 1, fc%n_terms(i)
-        READ(unit,*) fc%dat(i)%idx(:,j), fc%dat(i)%fc(j)
-      ENDDO
-      fc%dat(i)%fc = fc%dat(i)%fc*factor
-    ENDDO
-    !
-    CLOSE(unit)
-    ! Prepare the lists of R in cartesian coords
-    ALLOCATE(fc%xR2(3,fc%n_R), fc%xR3(3,fc%n_R))
-    fc%xR2 = REAL(fc%yR2, kind=DP)
-    CALL cryst_to_cart(fc%n_R,fc%xR2,S%at,1)
-    fc%xR3 = REAL(fc%yR3, kind=DP)
-    CALL cryst_to_cart(fc%n_R,fc%xR3,S%at,1)
-    !
-  END SUBROUTINE read_fc3_sparse
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE write_fc3_sparse(fc, filename, S)
-    USE input_fc, ONLY : write_system, ph_system_info
-    IMPLICIT NONE
-    CHARACTER(len=*),INTENT(in)          :: filename
-    TYPE(ph_system_info),INTENT(in)   :: S ! = System
-    CLASS(sparse),INTENT(in) :: fc
-    !
-    CHARACTER(len=14),PARAMETER :: sub = "write_fc3_sparse"
-    !
-    INTEGER :: unit, ios
-    INTEGER, EXTERNAL :: find_free_unit
-    CHARACTER (LEN=6), EXTERNAL :: int_to_char
-    !
-    INTEGER :: i, j, n_digits(3)
-    CHARACTER(len=64) :: cformat
-    !
-    unit = find_free_unit()
-    OPEN(unit=unit,file=filename,action='write',status='unknown',iostat=ios)
-    IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
-    !
-    WRITE(unit, '(a)') "sparse representation"
-    !
-    CALL write_system(unit, S)
-    WRITE(unit, '(3i9)') fc%nq
-    WRITE(unit, '(3i9)') fc%n_R
-    !
-    ! Writing with the minimum number of white spaces saves loads of disk space (unless you zip)
-    ! still keeping everything aligned for readability
-    IF(MAXVAL(fc%n_terms)>0)THEN
-      n_digits(1) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%n_terms))))) ! no need to leave space in front
-    ELSE
-      n_digits(1) = 1
-    ENDIF
-    n_digits(2) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%yR2)))+0.1_dp))+2 ! +2 to account minus signs
-    n_digits(3) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%yR3)))+0.1_dp))+2
-    cformat = '(i'//int_to_char(n_digits(1))// &
-              ',3i'//int_to_char(n_digits(2))// &
-              ',3i'//int_to_char(n_digits(3))//')'
-    !cformat = '(i9,3i6,3i6)' ! this also works
-    DO i = 1,fc%n_R
-      WRITE(unit, cformat) fc%n_terms(i),  fc%yR2(:,i), fc%yR3(:,i)
-    ENDDO
-    !
-    n_digits(1) = CEILING(LOG10(DBLE(3*S%nat)+0.1_dp))
-    n_digits(2) = n_digits(1)+1
-    !
-    cformat = '(i'//int_to_char(n_digits(1))// &
-              ',2i'//int_to_char(n_digits(2))//',1pe25.15)'
-    !cformat = '(i9,2i6,1pe25.14)' ! this also works
-    !
-    DO i = 1, fc%n_R
-      DO j = 1, fc%n_terms(i)
-        !
-        WRITE(unit,cformat) fc%dat(i)%idx(1:3,j), fc%dat(i)%fc(j)
-        !
-      ENDDO
-      WRITE(unit,*)
-    ENDDO
-    !
-    CLOSE(unit)
-    !
-  END SUBROUTINE write_fc3_sparse
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE destroy_fc3_sparse(fc)
-    USE input_fc, ONLY : write_system, ph_system_info
-    IMPLICIT NONE
-    CLASS(sparse),INTENT(inout) :: fc
-    INTEGER :: i
-    !
-    DEALLOCATE(fc%yR2)
-    DEALLOCATE(fc%yR3)
-    DEALLOCATE(fc%xR2)
-    DEALLOCATE(fc%xR3)
-    DO i = 1, fc%n_R
+      INTEGER :: unit, ios
+      INTEGER, EXTERNAL :: find_free_unit
+      CHARACTER(32) :: buf
+      CHARACTER(6) :: dummy
+      REAL(DP) :: factor
       !
-      DEALLOCATE(fc%dat(i)%idx)
-      DEALLOCATE(fc%dat(i)%fc)
+      INTEGER :: i, j
       !
-    ENDDO
-    DEALLOCATE(fc%dat)
-    !
-  END SUBROUTINE destroy_fc3_sparse
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE div_mass_fc3_sparse (fc,S)
-    USE kinds, only : DP
-    USE input_fc, ONLY : ph_system_info
-    IMPLICIT NONE
-    CLASS(sparse),INTENT(inout) :: fc
-    TYPE(ph_system_info),INTENT(in) :: S
-    !
-    INTEGER :: i, j
-    !
-    IF(.not.ALLOCATED(S%sqrtmm1)) &
-      call errore('div_mass_fc3_sparse', 'missing sqrtmm1, call aux_system first', 1)
-    
-    DO i = 1, fc%n_R
-      DO j = 1, fc%n_terms(i)
-        fc%dat(i)%fc(j) = fc%dat(i)%fc(j) &
-                         *S%sqrtmm1( fc%dat(i)%idx(1,j) ) &
-                         *S%sqrtmm1( fc%dat(i)%idx(2,j) ) &
-                         *S%sqrtmm1( fc%dat(i)%idx(3,j) )
+      unit = find_free_unit()
+      OPEN(unit=unit,file=filename,action='read',status='old',iostat=ios)
+      IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
+      !
+      READ(unit, '(a32)') buf
+      IF(buf(1:6)/="sparse") CALL errore(sub, "cannot read this format", 1)
+      READ(buf, *, iostat=ios) dummy, factor
+      IF(ios/=0) factor = 1._dp
+      IF(factor/=1._dp .and. ionode) WRITE(stdout, *) "WARNING! rescaling D3", factor
+      !
+      ioWRITE(stdout,*) "** Reading sparse FC3 file ", TRIM(filename)
+      CALL read_system(unit, S)
+      !
+      READ(unit, *) fc%nq
+      READ(unit, *) fc%n_R
+      ioWRITE(stdout,*) "   Original FC3 grid:", fc%nq
+      ioWRITE(stdout,*) "   Number of R:      ", fc%n_R
+      !
+      ALLOCATE(fc%n_terms(fc%n_R))
+      ALLOCATE(fc%yR2(3,fc%n_R), fc%yR3(3,fc%n_R))
+      DO i = 1,fc%n_R
+         READ(unit, *) fc%n_terms(i),  fc%yR2(:,i), fc%yR3(:,i)
       ENDDO
-    ENDDO
-    !
-  END SUBROUTINE div_mass_fc3_sparse
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE read_fc3_grid(fc, filename, S)
-    USE input_fc, ONLY : read_system
-    USE input_fc, ONLY : ph_system_info
-    IMPLICIT NONE
-    CHARACTER(len=*),INTENT(in)          :: filename
-    TYPE(ph_system_info),INTENT(inout)   :: S ! = System
-    CLASS(grid),INTENT(inout) :: fc
-    !
-    CHARACTER(len=13),PARAMETER :: sub = "read_fc3_grid"
-    !
-    INTEGER :: unit, ios
-    INTEGER, EXTERNAL :: find_free_unit
-    !
-    INTEGER :: na1,  na2,  na3,  j1,  j2,  j3, jn1, jn2, jn3
-    INTEGER :: na1_, na2_, na3_, j1_, j2_, j3_
-    INTEGER :: n_R, i
-    !
-    unit = find_free_unit()
-    OPEN(unit=unit,file=filename,action='read',status='old',iostat=ios)
-    IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
-    !
-    ioWRITE(stdout,*) "** Reading full grid FC3 file ", TRIM(filename)
-    !
-    CALL read_system(unit, S)
-    !
-    READ(unit, *) fc%nq
-    ioWRITE(stdout,*) "   Original FC3 grid:", fc%nq
-    !
-    DO na1=1,S%nat
-    DO na2=1,S%nat 
-    DO na3=1,S%nat 
-      DO j1=1,3
-      jn1 = j1 + (na1-1)*3
-      DO j2=1,3     
-      jn2 = j2 + (na2-1)*3
-      DO j3=1,3     
-      jn3 = j3 + (na3-1)*3
-          !
-          READ(unit,*) j1_, j2_, j3_, na1_, na2_, na3_
-          IF ( ANY((/na1,na2,na3,j1,j2,j3/) /= (/na1_,na2_,na3_,j1_,j2_,j3_/)) ) THEN
-            print*, (/na1,na2,na3,j1,j2,j3/)
-            print*, (/na1_,na2_,na3_,j1_,j2_,j3_/)
-            CALL errore(sub,'not matching na1,na2,na3,j1,j2,j3 in file "'//TRIM(filename)//"'",1)
-          ENDIF
-          !
-          READ(unit,*) n_R
-          IF ( fc%n_R == 0) THEN 
-            IF(allocated(fc%yR2) .or. allocated(fc%xR2) .or. &
-               allocated(fc%yR3) .or. allocated(fc%xR3) ) &
-              CALL errore(sub, 'some element are already allocated', 1)
+      !
+      ALLOCATE(fc%dat(fc%n_R))
+      !
+      DO i = 1, fc%n_R
+         !
+         ALLOCATE(fc%dat(i)%idx(3,fc%n_terms(i)))
+         ALLOCATE(fc%dat(i)%fc(fc%n_terms(i)))
+         !
+         DO j = 1, fc%n_terms(i)
+            READ(unit,*) fc%dat(i)%idx(:,j), fc%dat(i)%fc(j)
+         ENDDO
+         fc%dat(i)%fc = fc%dat(i)%fc*factor
+      ENDDO
+      !
+      CLOSE(unit)
+      ! Prepare the lists of R in cartesian coords
+      ALLOCATE(fc%xR2(3,fc%n_R), fc%xR3(3,fc%n_R))
+      fc%xR2 = REAL(fc%yR2, kind=DP)
+      CALL cryst_to_cart(fc%n_R,fc%xR2,S%at,1)
+      fc%xR3 = REAL(fc%yR3, kind=DP)
+      CALL cryst_to_cart(fc%n_R,fc%xR3,S%at,1)
+      !
+   END SUBROUTINE read_fc3_sparse
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE write_fc3_sparse(fc, filename, S)
+      USE input_fc, ONLY : write_system, ph_system_info
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(in)          :: filename
+      TYPE(ph_system_info),INTENT(in)   :: S ! = System
+      CLASS(sparse),INTENT(in) :: fc
+      !
+      CHARACTER(14),PARAMETER :: sub = "write_fc3_sparse"
+      !
+      INTEGER :: unit, ios
+      INTEGER, EXTERNAL :: find_free_unit
+      CHARACTER (6), EXTERNAL :: int_to_char
+      !
+      INTEGER :: i, j, n_digits(3)
+      CHARACTER(64) :: cformat
+      !
+      unit = find_free_unit()
+      OPEN(unit=unit,file=filename,action='write',status='unknown',iostat=ios)
+      IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
+      !
+      WRITE(unit, '(a)') "sparse representation"
+      !
+      CALL write_system(unit, S)
+      WRITE(unit, '(3i9)') fc%nq
+      WRITE(unit, '(3i9)') fc%n_R
+      !
+      ! Writing with the minimum number of white spaces saves loads of disk space (unless you zip)
+      ! still keeping everything aligned for readability
+      IF(MAXVAL(fc%n_terms)>0)THEN
+         n_digits(1) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%n_terms))))) ! no need to leave space in front
+      ELSE
+         n_digits(1) = 1
+      ENDIF
+      n_digits(2) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%yR2)))+0.1_dp))+2 ! +2 to account minus signs
+      n_digits(3) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%yR3)))+0.1_dp))+2
+      cformat = '(i'//int_to_char(n_digits(1))// &
+         ',3i'//int_to_char(n_digits(2))// &
+         ',3i'//int_to_char(n_digits(3))//')'
+      !cformat = '(i9,3i6,3i6)' ! this also works
+      DO i = 1,fc%n_R
+         WRITE(unit, cformat) fc%n_terms(i),  fc%yR2(:,i), fc%yR3(:,i)
+      ENDDO
+      !
+      n_digits(1) = CEILING(LOG10(DBLE(3*S%nat)+0.1_dp))
+      n_digits(2) = n_digits(1)+1
+      !
+      cformat = '(i'//int_to_char(n_digits(1))// &
+         ',2i'//int_to_char(n_digits(2))//',1pe25.15)'
+      !cformat = '(i9,2i6,1pe25.14)' ! this also works
+      !
+      DO i = 1, fc%n_R
+         DO j = 1, fc%n_terms(i)
             !
-            ioWRITE(stdout,*) "   Number of R:      ", n_R
-            ALLOCATE(fc%yR2(3,n_R), fc%yR3(3,n_R))
-            ALLOCATE(fc%xR2(3,n_R), fc%xR3(3,n_R))
-            ALLOCATE(fc%FC(3*S%nat,3*S%nat,3*S%nat,n_R))
-            fc%n_R = n_R
-          ELSE
-            IF(n_R/=fc%n_R) CALL errore(sub, "cannot read this fc format",1)
-          ENDIF
-          !
-          DO i = 1, fc%n_R
-            READ(unit,*) fc%yR2(:,i), fc%yR3(:,i), fc%FC(jn1,jn2,jn3,i)
-            ! also, find the index of R=0
-            IF( ALL(fc%yR2(:,i)==0) .and. ALL(fc%yR3(:,i)==0) ) fc%i_00 = i
-          ENDDO
+            WRITE(unit,cformat) fc%dat(i)%idx(1:3,j), fc%dat(i)%fc(j)
+            !
+         ENDDO
+         WRITE(unit,*)
       ENDDO
+      !
+      CLOSE(unit)
+      !
+   END SUBROUTINE write_fc3_sparse
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE destroy_fc3_sparse(fc)
+      USE input_fc, ONLY : write_system, ph_system_info
+      IMPLICIT NONE
+      CLASS(sparse),INTENT(inout) :: fc
+      INTEGER :: i
+      !
+      DEALLOCATE(fc%yR2)
+      DEALLOCATE(fc%yR3)
+      DEALLOCATE(fc%xR2)
+      DEALLOCATE(fc%xR3)
+      DO i = 1, fc%n_R
+         !
+         DEALLOCATE(fc%dat(i)%idx)
+         DEALLOCATE(fc%dat(i)%fc)
+         !
       ENDDO
+      DEALLOCATE(fc%dat)
+      !
+   END SUBROUTINE destroy_fc3_sparse
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE div_mass_fc3_sparse (fc,S)
+      USE kinds, only : DP
+      USE input_fc, ONLY : ph_system_info
+      IMPLICIT NONE
+      CLASS(sparse),INTENT(inout) :: fc
+      TYPE(ph_system_info),INTENT(in) :: S
+      !
+      INTEGER :: i, j
+      !
+      IF(.not.ALLOCATED(S%sqrtmm1)) &
+         call errore('div_mass_fc3_sparse', 'missing sqrtmm1, call aux_system first', 1)
+
+      DO i = 1, fc%n_R
+         DO j = 1, fc%n_terms(i)
+            fc%dat(i)%fc(j) = fc%dat(i)%fc(j) &
+               *S%sqrtmm1( fc%dat(i)%idx(1,j) ) &
+               *S%sqrtmm1( fc%dat(i)%idx(2,j) ) &
+               *S%sqrtmm1( fc%dat(i)%idx(3,j) )
+         ENDDO
       ENDDO
-    ENDDO
-    ENDDO
-    ENDDO
-    !
-    CLOSE(unit)
-    ! Prepare the lists of R in cartesian coords
-    fc%xR2 = REAL(fc%yR2, kind=DP)
-    CALL cryst_to_cart(n_R,fc%xR2,S%at,1)
-    fc%xR3 = REAL(fc%yR3, kind=DP)
-    CALL cryst_to_cart(n_R,fc%xR3,S%at,1)
-    !
-  END SUBROUTINE read_fc3_grid
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE write_fc3_grid(fc, filename, S)
-    USE input_fc, ONLY : write_system, ph_system_info
-    IMPLICIT NONE
-    CHARACTER(len=*),INTENT(in)          :: filename
-    TYPE(ph_system_info),INTENT(in)   :: S ! = System
-    CLASS(grid),INTENT(in) :: fc
-    !
-    CHARACTER(len=14),PARAMETER :: sub = "write_fc3_grid"
-    !
-    INTEGER :: unit, ios
-    INTEGER, EXTERNAL :: find_free_unit
-    ! format:
-    CHARACTER (LEN=6), EXTERNAL :: int_to_char
-    INTEGER :: n_digits(3)
-    CHARACTER(len=64) :: cformat, cformat2
-    !
-    INTEGER :: na1,  na2,  na3,  j1,  j2,  j3, jn1, jn2, jn3
-    INTEGER :: i
-    !
-    unit = find_free_unit()
-    OPEN(unit=unit,file=filename,action='write',status='unknown',iostat=ios)
-    IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
-    !
-    CALL write_system(unit, S)
-    !
-    WRITE(unit, '(3i9)') fc%nq
-    !
-    n_digits(1) = CEILING(LOG10(DBLE(S%nat)+0.1_dp))+1
-    cformat='(i1,2i2,x,3i'//int_to_char(n_digits(1))//')'
-    !
-    n_digits(2) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%yR2)))+0.1_dp))+2 ! +2 to account minus signs
-    n_digits(1) = n_digits(2)-1 ! no space at lines beginning
-    n_digits(3) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%yR3)))+0.1_dp))+2
-    !
-    cformat2 = '( i'//int_to_char(n_digits(1))// &
-               ',2i'//int_to_char(n_digits(2))// &
-               ',3i'//int_to_char(n_digits(3))//',1pe25.17,1pe13.3)'
-    !cformat2 = '(i6,2i6,3i6,1pe25.17,1pe13.3)'
-    !
-    DO na1=1,S%nat
-    DO na2=1,S%nat
-    DO na3=1,S%nat 
-      DO j1=1,3
-      jn1 = j1 + (na1-1)*3
-      DO j2=1,3     
-      jn2 = j2 + (na2-1)*3
-      DO j3=1,3     
-      jn3 = j3 + (na3-1)*3
-          !
-          WRITE(unit,cformat) j1, j2, j3, na1, na2, na3
-          !
-          WRITE(unit,'(i9)') fc%n_R
-          !
-          DO i = 1, fc%n_R
-            IF(allocated(fc%iFc))THEN
-              WRITE(unit,cformat2) fc%yR2(:,i), fc%yR3(:,i), fc%FC(jn1,jn2,jn3,i), fc%iFC(jn1,jn2,jn3,i)
-            ELSE
-              WRITE(unit,cformat2) fc%yR2(:,i), fc%yR3(:,i), fc%FC(jn1,jn2,jn3,i)
-            ENDIF
-          ENDDO
+      !
+   END SUBROUTINE div_mass_fc3_sparse
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE read_fc3_grid(fc, filename, S)
+      USE input_fc, ONLY : read_system
+      USE input_fc, ONLY : ph_system_info
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(in)          :: filename
+      TYPE(ph_system_info),INTENT(inout)   :: S ! = System
+      CLASS(grid),INTENT(inout) :: fc
+      !
+      CHARACTER(13),PARAMETER :: sub = "read_fc3_grid"
+      !
+      INTEGER :: unit, ios
+      INTEGER, EXTERNAL :: find_free_unit
+      !
+      INTEGER :: na1,  na2,  na3,  j1,  j2,  j3, jn1, jn2, jn3
+      INTEGER :: na1_, na2_, na3_, j1_, j2_, j3_
+      INTEGER :: n_R, i
+      !
+      unit = find_free_unit()
+      OPEN(unit=unit,file=filename,action='read',status='old',iostat=ios)
+      IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
+      !
+      ioWRITE(stdout,*) "** Reading full grid FC3 file ", TRIM(filename)
+      !
+      CALL read_system(unit, S)
+      !
+      READ(unit, *) fc%nq
+      ioWRITE(stdout,*) "   Original FC3 grid:", fc%nq
+      !
+      DO na1=1,S%nat
+         DO na2=1,S%nat
+            DO na3=1,S%nat
+               DO j1=1,3
+                  jn1 = j1 + (na1-1)*3
+                  DO j2=1,3
+                     jn2 = j2 + (na2-1)*3
+                     DO j3=1,3
+                        jn3 = j3 + (na3-1)*3
+                        !
+                        READ(unit,*) j1_, j2_, j3_, na1_, na2_, na3_
+                        IF ( ANY((/na1,na2,na3,j1,j2,j3/) /= (/na1_,na2_,na3_,j1_,j2_,j3_/)) ) THEN
+                           print*, (/na1,na2,na3,j1,j2,j3/)
+                           print*, (/na1_,na2_,na3_,j1_,j2_,j3_/)
+                           CALL errore(sub,'not matching na1,na2,na3,j1,j2,j3 in file "'//TRIM(filename)//"'",1)
+                        ENDIF
+                        !
+                        READ(unit,*) n_R
+                        IF ( fc%n_R == 0) THEN
+                           IF(allocated(fc%yR2) .or. allocated(fc%xR2) .or. &
+                              allocated(fc%yR3) .or. allocated(fc%xR3) ) &
+                              CALL errore(sub, 'some element are already allocated', 1)
+                           !
+                           ioWRITE(stdout,*) "   Number of R:      ", n_R
+                           ALLOCATE(fc%yR2(3,n_R), fc%yR3(3,n_R))
+                           ALLOCATE(fc%xR2(3,n_R), fc%xR3(3,n_R))
+                           ALLOCATE(fc%FC(3*S%nat,3*S%nat,3*S%nat,n_R))
+                           fc%n_R = n_R
+                        ELSE
+                           IF(n_R/=fc%n_R) CALL errore(sub, "cannot read this fc format",1)
+                        ENDIF
+                        !
+                        DO i = 1, fc%n_R
+                           READ(unit,*) fc%yR2(:,i), fc%yR3(:,i), fc%FC(jn1,jn2,jn3,i)
+                           ! also, find the index of R=0
+                           IF( ALL(fc%yR2(:,i)==0) .and. ALL(fc%yR3(:,i)==0) ) fc%i_00 = i
+                        ENDDO
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
+         ENDDO
       ENDDO
+      !
+      CLOSE(unit)
+      ! Prepare the lists of R in cartesian coords
+      fc%xR2 = REAL(fc%yR2, kind=DP)
+      CALL cryst_to_cart(n_R,fc%xR2,S%at,1)
+      fc%xR3 = REAL(fc%yR3, kind=DP)
+      CALL cryst_to_cart(n_R,fc%xR3,S%at,1)
+      !
+   END SUBROUTINE read_fc3_grid
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE write_fc3_grid(fc, filename, S)
+      USE input_fc, ONLY : write_system, ph_system_info
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(in)          :: filename
+      TYPE(ph_system_info),INTENT(in)   :: S ! = System
+      CLASS(grid),INTENT(in) :: fc
+      !
+      CHARACTER(14),PARAMETER :: sub = "write_fc3_grid"
+      !
+      INTEGER :: unit, ios
+      INTEGER, EXTERNAL :: find_free_unit
+      ! format:
+      CHARACTER (6), EXTERNAL :: int_to_char
+      INTEGER :: n_digits(3)
+      CHARACTER(64) :: cformat, cformat2
+      !
+      INTEGER :: na1,  na2,  na3,  j1,  j2,  j3, jn1, jn2, jn3
+      INTEGER :: i
+      !
+      unit = find_free_unit()
+      OPEN(unit=unit,file=filename,action='write',status='unknown',iostat=ios)
+      IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
+      !
+      CALL write_system(unit, S)
+      !
+      WRITE(unit, '(3i9)') fc%nq
+      !
+      n_digits(1) = CEILING(LOG10(DBLE(S%nat)+0.1_dp))+1
+      cformat='(i1,2i2,x,3i'//int_to_char(n_digits(1))//')'
+      !
+      n_digits(2) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%yR2)))+0.1_dp))+2 ! +2 to account minus signs
+      n_digits(1) = n_digits(2)-1 ! no space at lines beginning
+      n_digits(3) = CEILING(LOG10(DBLE(MAXVAL(ABS(fc%yR3)))+0.1_dp))+2
+      !
+      cformat2 = '( i'//int_to_char(n_digits(1))// &
+         ',2i'//int_to_char(n_digits(2))// &
+         ',3i'//int_to_char(n_digits(3))//',1pe25.17,1pe13.3)'
+      !cformat2 = '(i6,2i6,3i6,1pe25.17,1pe13.3)'
+      !
+      DO na1=1,S%nat
+         DO na2=1,S%nat
+            DO na3=1,S%nat
+               DO j1=1,3
+                  jn1 = j1 + (na1-1)*3
+                  DO j2=1,3
+                     jn2 = j2 + (na2-1)*3
+                     DO j3=1,3
+                        jn3 = j3 + (na3-1)*3
+                        !
+                        WRITE(unit,cformat) j1, j2, j3, na1, na2, na3
+                        !
+                        WRITE(unit,'(i9)') fc%n_R
+                        !
+                        DO i = 1, fc%n_R
+                           IF(allocated(fc%iFc))THEN
+                              WRITE(unit,cformat2) fc%yR2(:,i), fc%yR3(:,i), fc%FC(jn1,jn2,jn3,i), fc%iFC(jn1,jn2,jn3,i)
+                           ELSE
+                              WRITE(unit,cformat2) fc%yR2(:,i), fc%yR3(:,i), fc%FC(jn1,jn2,jn3,i)
+                           ENDIF
+                        ENDDO
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
+         ENDDO
       ENDDO
+      !
+      CLOSE(unit)
+      !
+   END SUBROUTINE write_fc3_grid
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE destroy_fc3_grid(fc)
+      USE input_fc, ONLY : write_system
+      IMPLICIT NONE
+      CLASS(grid),INTENT(inout) :: fc
+      !
+      DEALLOCATE(fc%yR2)
+      DEALLOCATE(fc%yR3)
+      DEALLOCATE(fc%xR2)
+      DEALLOCATE(fc%xR3)
+      DEALLOCATE(fc%FC)
+      !
+   END SUBROUTINE destroy_fc3_grid
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE div_mass_fc3_grid(fc,S)
+      USE kinds,    ONLY : DP
+      USE input_fc, ONLY : ph_system_info
+      IMPLICIT NONE
+      CLASS(grid),INTENT(inout) :: fc
+      TYPE(ph_system_info),INTENT(in) :: S
+      !
+      INTEGER :: i, j, k, i_R
+      !
+      IF(.not.ALLOCATED(S%sqrtmm1)) &
+         call errore('div_mass_fc3_grid', 'missing sqrtmm1, call aux_system first', 1)
+
+      DO i_R = 1, fc%n_R
+         DO k = 1, S%nat3
+            DO j = 1, S%nat3
+               DO i = 1, S%nat3
+                  fc%FC(i, j, k, i_R) = fc%FC(i, j, k, i_R) &
+                     * S%sqrtmm1(i)*S%sqrtmm1(j)*S%sqrtmm1(k)
+               ENDDO
+            ENDDO
+         ENDDO
       ENDDO
-    ENDDO
-    ENDDO
-    ENDDO
-    !
-    CLOSE(unit)
-    !
-  END SUBROUTINE write_fc3_grid
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE destroy_fc3_grid(fc)
-    USE input_fc, ONLY : write_system
-    IMPLICIT NONE
-    CLASS(grid),INTENT(inout) :: fc
-    !
-    DEALLOCATE(fc%yR2)
-    DEALLOCATE(fc%yR3)
-    DEALLOCATE(fc%xR2)
-    DEALLOCATE(fc%xR3)
-    DEALLOCATE(fc%FC)
-    !
-  END SUBROUTINE destroy_fc3_grid
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE div_mass_fc3_grid(fc,S)
-    USE kinds,    ONLY : DP
-    USE input_fc, ONLY : ph_system_info
-    IMPLICIT NONE
-    CLASS(grid),INTENT(inout) :: fc
-    TYPE(ph_system_info),INTENT(in) :: S
-    !
-    INTEGER :: i, j, k, i_R
-    !
-    IF(.not.ALLOCATED(S%sqrtmm1)) &
-      call errore('div_mass_fc3_grid', 'missing sqrtmm1, call aux_system first', 1)
-    
-    DO i_R = 1, fc%n_R
-      DO k = 1, S%nat3
-      DO j = 1, S%nat3
-      DO i = 1, S%nat3
-        fc%FC(i, j, k, i_R) = fc%FC(i, j, k, i_R) &
-                    * S%sqrtmm1(i)*S%sqrtmm1(j)*S%sqrtmm1(k)
-      ENDDO
-      ENDDO
-      ENDDO
-    ENDDO
-    !
-  END SUBROUTINE div_mass_fc3_grid
-  !
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE destroy_fc3_(fc)
-    IMPLICIT NONE
-    CLASS(forceconst3),INTENT(inout) :: fc
-    !
-    DEALLOCATE(fc%yR2)
-    DEALLOCATE(fc%yR3)
-    DEALLOCATE(fc%xR2)
-    DEALLOCATE(fc%xR3)
-    !
-  END SUBROUTINE destroy_fc3_
-  !
+      !
+   END SUBROUTINE div_mass_fc3_grid
+   !
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE destroy_fc3_(fc)
+      IMPLICIT NONE
+      CLASS(forceconst3),INTENT(inout) :: fc
+      !
+      DEALLOCATE(fc%yR2)
+      DEALLOCATE(fc%yR3)
+      DEALLOCATE(fc%xR2)
+      DEALLOCATE(fc%xR3)
+      !
+   END SUBROUTINE destroy_fc3_
+   !
 !       procedure :: interpolate  => fftinterp_mat3_constant
 !       procedure :: destroy      => destroy_fc3_constant
 !       procedure :: read         => read_fc3_constant
 !       procedure :: write        => write_fc3_constant
-!       procedure :: div_mass     => div_mass_fc3_constant  
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fftinterp_mat3_constant(fc, xq2,xq3, nat3, D)
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(constant),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    !
-    D = fc%D
-    !
-  END SUBROUTINE fftinterp_mat3_constant
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE fft_doubleinterp_mat3_constant(fc, xq2,xq3,xq3b, nat3, D, Db)
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)   :: nat3
-    CLASS(constant),INTENT(in) :: fc
-    REAL(DP),INTENT(in) :: xq2(3), xq3(3), xq3b(3)
-    COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
-    COMPLEX(DP),INTENT(out) :: Db(nat3, nat3, nat3)
-    D  = fc%D
-    Db = fc%D
-  END SUBROUTINE fft_doubleinterp_mat3_constant
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE div_mass_fc3_constant(fc,S)
-    USE kinds,    ONLY : DP
-    USE input_fc, ONLY : ph_system_info
-    IMPLICIT NONE
-    CLASS(constant),INTENT(inout) :: fc
-    TYPE(ph_system_info),INTENT(in) :: S
-    !
-    INTEGER :: i, j, k, i_R
-    !
-    IF(.not.ALLOCATED(S%sqrtmm1)) &
-      call errore('div_mass_fc3_grid', 'missing sqrtmm1, call aux_system first', 1)
-    
-    ALLOCATE(fc%D(S%nat3, S%nat3, S%nat3))
-    fc%D = fc%constant
-    !
-    DO k = 1, S%nat3
-    DO j = 1, S%nat3
-    DO i = 1, S%nat3
-      fc%D(i, j, k) = fc%D(i, j, k) &
-                  * S%sqrtmm1(i)*S%sqrtmm1(j)*S%sqrtmm1(k)
-    ENDDO
-    ENDDO
-    ENDDO
-    !
-  END SUBROUTINE div_mass_fc3_constant
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE destroy_fc3_constant(fc)
-    IMPLICIT NONE
-    CLASS(constant),INTENT(inout) :: fc
-    !
-    DEALLOCATE(fc%D)
-    fc%constant = 0._dp
-    !
-  END SUBROUTINE destroy_fc3_constant
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE read_fc3_constant(fc, filename, S)
-    USE input_fc, ONLY : read_system
-    USE input_fc, ONLY : ph_system_info
-    IMPLICIT NONE
-    CHARACTER(len=*),INTENT(in)          :: filename
-    TYPE(ph_system_info),INTENT(inout)   :: S ! = System
-    CLASS(constant),INTENT(inout) :: fc
-    INTEGER :: unit, ios
-    CHARACTER(len=17),PARAMETER :: sub = "read_fc3_constant"
-    CHARACTER(len=32) :: buf
-    INTEGER,EXTERNAL :: find_free_unit
-    !
-    unit = find_free_unit()
-    OPEN(unit=unit,file=filename,action='read',status='old',iostat=ios)
-    IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
-    !
-    READ(unit, '(a32)') buf
-    IF(buf/="constant") CALL errore(sub, "cannot read this format", 1)
-    !
-    ioWRITE(stdout,*) "** Reading constant FC3 file ", TRIM(filename)
-    CALL read_system(unit, S)
-    READ(unit, *) fc%constant
-    WRITE(stdout,*) "Constant FC", fc%constant
-    RETURN
-    !
-  END SUBROUTINE read_fc3_constant
-  ! \/o\________\\\______________________//\/___________________/~^>>
-  SUBROUTINE write_fc3_constant(fc, filename, S)
-    USE input_fc, ONLY : write_system, ph_system_info
-    IMPLICIT NONE
-    CHARACTER(len=*),INTENT(in)          :: filename
-    TYPE(ph_system_info),INTENT(in)   :: S ! = System
-    CLASS(constant),INTENT(in) :: fc
-    CHARACTER(len=14),PARAMETER :: sub = "write_fc3_constant"
-    INTEGER :: unit, ios
-    INTEGER, EXTERNAL :: find_free_unit
-    !
-    unit = find_free_unit()
-    OPEN(unit=unit,file=filename,action='write',status='unknown',iostat=ios)
-    IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
-    !
-    WRITE(unit, '(a)') "constant"
-    CALL write_system(unit, S)
-    WRITE(unit,*) FC%constant
-  END SUBROUTINE write_fc3_constant
-  ! \/o\________\\\______________________//\/___________________/~^>>
+!       procedure :: div_mass     => div_mass_fc3_constant
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_constant(fc, xq2,xq3, nat3, D)
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(constant),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      !
+      D = fc%D
+      !
+   END SUBROUTINE fftinterp_mat3_constant
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fftinterp_mat3_constant_grad(fc, xq2,xq3, nat3, D, Dgrad)
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(constant),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      COMPLEX(DP),INTENT(out) :: Dgrad(nat3, nat3, nat3,3)
 
-  SUBROUTINE ip_cart2pat(d3in, nat3, u1, u2, u3)
-    ! Rotates D3 matrix from cartesian axis to the basis
-    ! of the modes. Rotation is not really in place
-    USE kinds, ONLY : DP
-    IMPLICIT NONE
-    ! d3 matrix, input: in cartesian basis, output: on the patterns basis
-    COMPLEX(DP),INTENT(inout) :: d3in(nat3, nat3, nat3)
-    INTEGER,INTENT(in)        :: nat3
-    ! patterns (transposed, with respect to what we use in the d3q.x code)
-    COMPLEX(DP),INTENT(in)    :: u1(nat3, nat3), u2(nat3, nat3), u3(nat3, nat3) 
-    !
-    INTEGER :: a, b, c, i, j, k
-    COMPLEX(DP),ALLOCATABLE  :: d3tmp(:,:,:)
-    COMPLEX(DP),ALLOCATABLE :: AUX(:,:)
-    COMPLEX(DP),PARAMETER :: Z1 = (1._dp, 0._dp)
-    COMPLEX(DP) :: u1t(nat3,nat3)
-    !
-    ALLOCATE(AUX(nat3,nat3))
-    ALLOCATE(d3tmp(nat3, nat3, nat3))
-    d3tmp = 0._dp
-    !
-    u1t = TRANSPOSE(CONJG(u1))
-    !
-!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j,k,a,b,c,AUX) REDUCTION(+: d3tmp) COLLAPSE(2)
-    DO c = 1,nat3
-    DO b = 1,nat3
-      ! Precompute u2*u3 to save some FLOPS without 
-      ! compromising memory access order
-      DO k = 1,nat3
-      DO j = 1,nat3
-        AUX(j,k) = CONJG(u2(b,j) * u3(c,k))
-      ENDDO
+      !
+      D = fc%D
+      Dgrad = 0._dp
+      !
+   END SUBROUTINE fftinterp_mat3_constant_grad
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE fft_doubleinterp_mat3_constant(fc, xq2,xq3,xq3b, nat3, D, Db)
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)   :: nat3
+      CLASS(constant),INTENT(in) :: fc
+      REAL(DP),INTENT(in) :: xq2(3), xq3(3), xq3b(3)
+      COMPLEX(DP),INTENT(out) :: D(nat3, nat3, nat3)
+      COMPLEX(DP),INTENT(out) :: Db(nat3, nat3, nat3)
+      D  = fc%D
+      Db = fc%D
+   END SUBROUTINE fft_doubleinterp_mat3_constant
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE div_mass_fc3_constant(fc,S)
+      USE kinds,    ONLY : DP
+      USE input_fc, ONLY : ph_system_info
+      IMPLICIT NONE
+      CLASS(constant),INTENT(inout) :: fc
+      TYPE(ph_system_info),INTENT(in) :: S
+      !
+      INTEGER :: i, j, k, i_R
+      !
+      IF(.not.ALLOCATED(S%sqrtmm1)) &
+         call errore('div_mass_fc3_grid', 'missing sqrtmm1, call aux_system first', 1)
+
+      ALLOCATE(fc%D(S%nat3, S%nat3, S%nat3))
+      fc%D = fc%constant
+      !
+      DO k = 1, S%nat3
+         DO j = 1, S%nat3
+            DO i = 1, S%nat3
+               fc%D(i, j, k) = fc%D(i, j, k) &
+                  * S%sqrtmm1(i)*S%sqrtmm1(j)*S%sqrtmm1(k)
+            ENDDO
+         ENDDO
       ENDDO
       !
-      DO a = 1,nat3
-        DO k = 1,nat3
-        DO j = 1,nat3
-        DO i = 1,nat3
-              d3tmp(i, j, k) = d3tmp(i, j, k) &
-                              + u1t(i,a) * AUX(j,k) * d3in(a, b, c) 
-        ENDDO
-        ENDDO
-        ENDDO
+   END SUBROUTINE div_mass_fc3_constant
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE destroy_fc3_constant(fc)
+      IMPLICIT NONE
+      CLASS(constant),INTENT(inout) :: fc
+      !
+      DEALLOCATE(fc%D)
+      fc%constant = 0._dp
+      !
+   END SUBROUTINE destroy_fc3_constant
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE read_fc3_constant(fc, filename, S)
+      USE input_fc, ONLY : read_system
+      USE input_fc, ONLY : ph_system_info
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(in)          :: filename
+      TYPE(ph_system_info),INTENT(inout)   :: S ! = System
+      CLASS(constant),INTENT(inout) :: fc
+      INTEGER :: unit, ios
+      CHARACTER(17),PARAMETER :: sub = "read_fc3_constant"
+      CHARACTER(32) :: buf
+      INTEGER,EXTERNAL :: find_free_unit
+      !
+      unit = find_free_unit()
+      OPEN(unit=unit,file=filename,action='read',status='old',iostat=ios)
+      IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
+      !
+      READ(unit, '(a32)') buf
+      IF(buf/="constant") CALL errore(sub, "cannot read this format", 1)
+      !
+      ioWRITE(stdout,*) "** Reading constant FC3 file ", TRIM(filename)
+      CALL read_system(unit, S)
+      READ(unit, *) fc%constant
+      WRITE(stdout,*) "Constant FC", fc%constant
+      RETURN
+      !
+   END SUBROUTINE read_fc3_constant
+   ! \/o\________\\\______________________//\/___________________/~^>>
+   SUBROUTINE write_fc3_constant(fc, filename, S)
+      USE input_fc, ONLY : write_system, ph_system_info
+      IMPLICIT NONE
+      CHARACTER(*),INTENT(in)          :: filename
+      TYPE(ph_system_info),INTENT(in)   :: S ! = System
+      CLASS(constant),INTENT(in) :: fc
+      CHARACTER(14),PARAMETER :: sub = "write_fc3_constant"
+      INTEGER :: unit, ios
+      INTEGER, EXTERNAL :: find_free_unit
+      !
+      unit = find_free_unit()
+      OPEN(unit=unit,file=filename,action='write',status='unknown',iostat=ios)
+      IF(ios/=0) CALL errore(sub,"opening '"//TRIM(filename)//"'", 1)
+      !
+      WRITE(unit, '(a)') "constant"
+      CALL write_system(unit, S)
+      WRITE(unit,*) FC%constant
+   END SUBROUTINE write_fc3_constant
+   ! \/o\________\\\______________________//\/___________________/~^>>
+
+   SUBROUTINE ip_cart2pat(d3in, nat3, u1, u2, u3)
+      ! Rotates D3 matrix from cartesian axis to the basis
+      ! of the modes. Rotation is not really in place
+      USE kinds, ONLY : DP
+      IMPLICIT NONE
+      ! d3 matrix, input: in cartesian basis, output: on the patterns basis
+      COMPLEX(DP),INTENT(inout) :: d3in(nat3, nat3, nat3)
+      INTEGER,INTENT(in)        :: nat3
+      ! patterns (transposed, with respect to what we use in the d3q.x code)
+      COMPLEX(DP),INTENT(in)    :: u1(nat3, nat3), u2(nat3, nat3), u3(nat3, nat3)
+      !
+      INTEGER :: a, b, c, i, j, k
+      COMPLEX(DP),ALLOCATABLE  :: d3tmp(:,:,:)
+      COMPLEX(DP),ALLOCATABLE :: AUX(:,:)
+      COMPLEX(DP),PARAMETER :: Z1 = (1._dp, 0._dp)
+      COMPLEX(DP) :: u1t(nat3,nat3)
+      !
+      ALLOCATE(AUX(nat3,nat3))
+      ALLOCATE(d3tmp(nat3, nat3, nat3))
+      d3tmp = 0._dp
+      !
+      ! u1t = TRANSPOSE(CONJG(u1))
+      !
+!$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(i,j,k,a,b,c,AUX) REDUCTION(+: d3tmp) COLLAPSE(2)
+      DO c = 1,nat3
+         DO b = 1,nat3
+            ! Precompute u2*u3 to save some FLOPS without
+            ! compromising memory access order
+            DO k = 1,nat3
+               DO j = 1,nat3
+                  AUX(j,k) = u2(b,j) * u3(c,k)
+               ENDDO
+            ENDDO
+            !
+            DO a = 1,nat3
+               DO k = 1,nat3
+                  DO j = 1,nat3
+                     DO i = 1,nat3
+                        d3tmp(i, j, k) = d3tmp(i, j, k) &
+                           + CONJG(u1(a,i) * AUX(j,k)) * d3in(a, b, c)
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
+         ENDDO
       ENDDO
-    ENDDO
-    ENDDO
 !$OMP END PARALLEL DO
-    !
-    d3in = d3tmp
-    DEALLOCATE(d3tmp)
-    !
-    RETURN
-    !
-    RETURN
-  END SUBROUTINE ip_cart2pat
-    !
-  END MODULE
+      !
+      d3in = d3tmp
+      DEALLOCATE(d3tmp)
+      !
+      RETURN
+      !
+      RETURN
+   END SUBROUTINE ip_cart2pat
+   !
+   SUBROUTINE ip_cart2pat_gemm(d3in, nat3, u1, u2, u3)
+      USE kinds, ONLY : DP
+      IMPLICIT NONE
+      ! Inputs/outputs
+      COMPLEX(DP), INTENT(INOUT) :: d3in(nat3, nat3, nat3)
+      INTEGER, INTENT(IN)        :: nat3
+      COMPLEX(DP), INTENT(IN)    :: u1(nat3, nat3), u2(nat3, nat3), u3(nat3, nat3)
+   
+      ! Temporary arrays
+      COMPLEX(DP), ALLOCATABLE :: tmp(:,:,:)
+      INTEGER :: i, k, nat32
+      COMPLEX(DP) :: u3c(nat3, nat3)
+   
+      ! Allocate temporary arrays
+      ALLOCATE(tmp(nat3, nat3, nat3))
+      ! ALLOCATE(tmp2(nat3, nat3, nat3))
+   
+      ! Initialize temporary arrays
+      tmp = 0._dp
+      ! tmp2 = 0._dp
+      nat32 = nat3**2
+   
+      ! d3(i,j,k) = u(a,i) * u(b,j) * u(c,k) * d3in(a,b,c)
+   
+      u3c = CONJG(u3)
+      ! Step 1: tmp(a,b,k) = d3in(a,b,c) * CONJG(u3(c,k))
+      CALL zgemm('N', 'N', nat32, nat3, nat3, 1.0_DP, d3in, nat32, u3c, nat3, 0.0_DP, tmp, nat32)
+   
+      ! ! Step 2: tmp2(i,b,k) = TRANSCONJ(u(a,i)) * tmp(a,b,k)
+      CALL zgemm('C', 'N', nat3, nat32, nat3, 1.0_DP, u1, nat3, tmp, nat3, 0.0_DP, d3in, nat3)
+   
+      ! Step 3: tmp(b,i,k) = RESHAPE(tmp2(i,b,k))
+      do k = 1, nat3
+         tmp(:, :, k) = TRANSPOSE(d3in(:, :, k))
+      enddo
+   
+      ! Step 3: d3in(i,j,k) = TRANSCONJ(u2(b,j)) * tmp(b,i,k)
+      CALL zgemm('C', 'N', nat3, nat32, nat3, 1.0_DP, u2, nat3, tmp, nat3, 0.0_DP, d3in, nat3)
+   
+      do k = 1, nat3
+         d3in(:, :, k) = TRANSPOSE(d3in(:, :, k))
+      enddo
+   
+      ! Deallocate temporary arrays
+      DEALLOCATE(tmp)
+      ! DEALLOCATE(tmp2)
+   
+      RETURN
+   END SUBROUTINE
+
+END MODULE

--- a/thermal2/fc3_interp.f90
+++ b/thermal2/fc3_interp.f90
@@ -1510,10 +1510,10 @@ CONTAINS
    
       u3c = CONJG(u3)
       ! Step 1: tmp(a,b,k) = d3in(a,b,c) * CONJG(u3(c,k))
-      CALL zgemm('N', 'N', nat32, nat3, nat3, 1.0_DP, d3in, nat32, u3c, nat3, 0.0_DP, tmp, nat32)
+      CALL zgemm3m('N', 'N', nat32, nat3, nat3, 1.0_DP, d3in, nat32, u3c, nat3, 0.0_DP, tmp, nat32)
    
       ! ! Step 2: tmp2(i,b,k) = TRANSCONJ(u(a,i)) * tmp(a,b,k)
-      CALL zgemm('C', 'N', nat3, nat32, nat3, 1.0_DP, u1, nat3, tmp, nat3, 0.0_DP, d3in, nat3)
+      CALL zgemm3m('C', 'N', nat3, nat32, nat3, 1.0_DP, u1, nat3, tmp, nat3, 0.0_DP, d3in, nat3)
    
       ! Step 3: tmp(b,i,k) = RESHAPE(tmp2(i,b,k))
       do k = 1, nat3
@@ -1521,7 +1521,7 @@ CONTAINS
       enddo
    
       ! Step 3: d3in(i,j,k) = TRANSCONJ(u2(b,j)) * tmp(b,i,k)
-      CALL zgemm('C', 'N', nat3, nat32, nat3, 1.0_DP, u2, nat3, tmp, nat3, 0.0_DP, d3in, nat3)
+      CALL zgemm3m('C', 'N', nat3, nat32, nat3, 1.0_DP, u2, nat3, tmp, nat3, 0.0_DP, d3in, nat3)
    
       do k = 1, nat3
          d3in(:, :, k) = TRANSPOSE(d3in(:, :, k))

--- a/thermal2/linewidth.f90
+++ b/thermal2/linewidth.f90
@@ -16,7 +16,7 @@ MODULE linewidth
    USE kinds,            ONLY : DP
    USE mpi_thermal,      ONLY : my_id, num_procs, mpi_bsum, allgather_mat, scatteri_tns, mpi_sum_mat
    USE constants,        ONLY : RY_TO_CMM1, PI
-   USE q_grids,          ONLY : q_grid, setup_grid, fc_info
+   USE q_grids,          ONLY : q_grid, setup_grid
    USE input_fc,         ONLY : ph_system_info
    USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat_gemm, d3_mixed
    USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0

--- a/thermal2/linewidth.f90
+++ b/thermal2/linewidth.f90
@@ -13,745 +13,1120 @@
 MODULE linewidth
 
 #include "mpi_thermal.h"
-  USE kinds,       ONLY : DP
-  USE mpi_thermal, ONLY : my_id, mpi_bsum
-  USE constants,   ONLY : RY_TO_CMM1
-  USE timers
+   USE kinds,            ONLY : DP
+   USE mpi_thermal,      ONLY : my_id, num_procs, mpi_bsum, allgather_mat, scatteri_tns, mpi_sum_mat
+   USE constants,        ONLY : RY_TO_CMM1, PI
+   USE q_grids,          ONLY : q_grid, setup_grid, fc_info
+   USE input_fc,         ONLY : ph_system_info
+   USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat_gemm, d3_mixed
+   USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
+   USE functions,        ONLY : refold_bz
+   USE code_input,       ONLY : code_input_type
+   USE timers
+CONTAINS
 
-  CONTAINS
+   SUBROUTINE check_negative_lw(lw, xq, nat3, nconf, name)
+      IMPLICIT NONE
+      REAL(DP),INTENT(in) :: lw(nat3, nconf)
+      real(DP),INTENT(in) :: xq(3)
+      INTEGER,INTENT(in)  :: nat3, nconf
+      CHARACTER(*),INTENT(in) :: name
+      !
+      EXTERNAL errore
+      !
+      INTEGER :: i,j
+      IF(ANY(lw<0._dp))THEN
+         DO i = 1,nconf
+            DO j = 1,nat3
+               IF(lw(j,i) < 0._dp) THEN
+                  WRITE(*,*) i, j, lw(j,i)
+                  WRITE(*,'(3E13.2)') xq
+               ENDIF
+            ENDDO
+         ENDDO
+         CALL errore(name, "negative linewidth", 1)
+      ENDIF
+      RETURN
+   END SUBROUTINE
 
 ! <<^V^\\=========================================//-//-//========//O\\//
-  FUNCTION linewidth_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, freq1, U1, lw_UN)
-    USE q_grids,          ONLY : q_grid
-    USE input_fc,         ONLY : ph_system_info
-    USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
-    USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
-    USE functions,        ONLY : refold_bz
-    IMPLICIT NONE
-    !
-    REAL(DP),INTENT(in) :: xq0(3)
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
-    !
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: grid
-    REAL(DP),INTENT(in) :: sigma(nconf) ! ry
-    !
-    REAL(DP),OPTIONAL,INTENT(out)   :: lw_UN(S%nat3,2,nconf) ! Normal/Umklapp contribution
-    REAL(DP),OPTIONAL,INTENT(in)    :: freq1(S%nat3)
-    COMPLEX(DP),OPTIONAL,INTENT(in) :: U1(S%nat3,S%nat3)
-    !
-    ! FUNCTION RESULT:
-    REAL(DP) :: linewidth_q(S%nat3,nconf)
-    REAL(DP) :: lw(S%nat3,nconf) !aux
-    !
-    COMPLEX(DP),ALLOCATABLE :: U(:,:,:), D3(:,:,:)
-    REAL(DP),ALLOCATABLE    :: V3sq(:,:,:)
-    INTEGER :: iq, jq, nu, it, nu0(3), j_un
-    INTEGER,PARAMETER :: normal=1, umklapp=2
-    !
-    REAL(DP) :: freq(S%nat3,3), bose(S%nat3,3), xq(3,3), xq_aux(3), aux(S%nat3)
-    !
-
-    ALLOCATE(U(S%nat3, S%nat3,3))
-    ALLOCATE(V3sq(S%nat3, S%nat3, S%nat3))
-    ALLOCATE(D3(S%nat3, S%nat3, S%nat3))
-    !
-    lw = 0._dp
-    IF(present(lw_UN)) lw_UN = 0._dp
-    !
-    ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q1
-      timer_CALL t_freq%start()
-    xq(:,1) = xq0
-    nu0(1) = set_nu0(xq(:,1), S%at)
-    IF(present(freq1) .and. present(U1)) THEN
-      freq(:,1) = freq1
-      U(:,:,1)    = U1
-    ELSE
-      CALL freq_phq_safe(xq(:,1), S, fc2, freq(:,1), U(:,:,1))
-    ENDIF
-        timer_CALL t_freq%stop()
-    !
-    !WRITE(*,*) "Summing over a grid of", grid%nq, " points"
-    DO iq = 1, grid%nq
+   SUBROUTINE weights_tetra(grid, xq0, S, fc2, weights_C, weights_X)
+      ! USE q_grids,          ONLY : q_grid
+      ! USE constants,        ONLY : pi
+      ! USE input_fc,         ONLY : ph_system_info
+      ! USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
+      ! USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
+      ! USE functions,        ONLY : refold_bz
+      USE thtetra,          ONLY : tetra_init, tetra_weights_delta_vec
+      IMPLICIT NONE
       !
-        timer_CALL t_freq%start()
-      ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q2 and q3
-      xq(:,2) = grid%xq(:,iq)
-      xq(:,3) = -(xq(:,2)+xq(:,1))
-      IF(present(lw_UN)) THEN
-        xq_aux = refold_bz(xq(:,1), S%bg) &
-                +refold_bz(xq(:,2), S%bg) &
-                +refold_bz(xq(:,3), S%bg)
-        IF(ALL(ABS(xq_aux)<1.d-6)) THEN
-          j_un = normal
-        ELSE
-          j_un = umklapp
-        ENDIF
+      TYPE(q_grid), INTENT(IN) :: grid
+      REAL(DP), INTENT(IN) :: xq0(3)
+      TYPE(ph_system_info), INTENT(IN) :: S
+      TYPE(forceconst2_grid), INTENT(IN) :: fc2
+      REAL(DP), INTENT(OUT) :: weights_C(S%nat3, S%nat3**2, grid%nqtot), weights_X(S%nat3, S%nat3**2, grid%nqtot)
+      INTEGER :: iq, ibnd, jbnd, index_double
+      REAL(DP) :: freqs_doubled_X(S%nat3**2, grid%nq), freqs_doubled_C(S%nat3**2, grid%nq)
+      REAL(DP), ALLOCATABLE :: gather_doubled_X(:,:), gather_doubled_C(:,:)
+      REAL(DP) :: xq(3,3), freq(S%nat3,3)
+      !
+
+      ! ALLOCATE(weights_X(nat3, nat3**2, grid%nqtot), weights_C(nat3, nat3**2, grid%nqtot))
+      !
+      xq(:,1) = xq0
+      CALL freq_phq_safe(xq(:,1), S, fc2, freq(:,1))
+      ! this cycle initializes freqs, as a grid of frequencies
+      ! this cycle initializes freqs_doubled, which is freq(ibnd,2) +/- freq(jbnd,3)
+      timer_CALL t_freqd%start()
+      DO iq = 1, grid%nq
+         CALL freq_phq_safe(grid%xq(:,iq), S, fc2, freq(:,2))
+         ! the third vector (why it's minus?)
+         xq(:,3) = -(grid%xq(:,iq)+xq(:,1))
+         CALL freq_phq_safe(xq(:,3), S, fc2, freq(:,3))
+         DO ibnd = 1, S%nat3
+            DO jbnd = 1, S%nat3
+               index_double = S%nat3*(ibnd-1) + jbnd
+               freqs_doubled_X(index_double,iq) = freq(ibnd,2) + freq(jbnd,3)
+               freqs_doubled_C(index_double,iq) = freq(jbnd,3) - freq(ibnd,2)
+            ENDDO
+         ENDDO
+      ENDDO
+      IF(grid%scattered) THEN
+         CALL allgather_mat(S%nat3**2, grid%nq, freqs_doubled_X, gather_doubled_X)
+         CALL allgather_mat(S%nat3**2, grid%nq, freqs_doubled_C, gather_doubled_C)
+      else
+         ALLOCATE(gather_doubled_X(S%nat3**2, grid%nq))
+         ALLOCATE(gather_doubled_C(S%nat3**2, grid%nq))
+         gather_doubled_X = freqs_doubled_X
+         gather_doubled_C = freqs_doubled_C
       ENDIF
 
-!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
-      DO jq = 2,3
-        nu0(jq) = set_nu0(xq(:,jq), S%at)
-        CALL freq_phq_safe(xq(:,jq), S, fc2, freq(:,jq), U(:,:,jq))
-      ENDDO
-!$OMP END PARALLEL DO
-        timer_CALL t_freq%stop()
-      !
-        timer_CALL t_fc3int%start()
-      CALL fc3%interpolate(xq(:,2), xq(:,3), S%nat3, D3)
-        timer_CALL t_fc3int%stop()
-        timer_CALL t_fc3rot%start()
-      CALL ip_cart2pat(D3, S%nat3, U(:,:,1), U(:,:,2), U(:,:,3))
-        timer_CALL t_fc3rot%stop()
-        timer_CALL t_fc3m2%start()
-      V3sq = REAL( CONJG(D3)*D3 , kind=DP)
-        timer_CALL t_fc3m2%stop()
-      !
-      DO it = 1,nconf
-          timer_CALL t_bose%start()
-        ! Compute bose-einstein occupation at q2 and q3
-!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
-        DO jq = 1,3
-          CALL bose_phq(T(it),S%nat3, freq(:,jq), bose(:,jq))
-        ENDDO
-!$OMP END PARALLEL DO
-          timer_CALL t_bose%stop()
-          timer_CALL t_sum%start()
-        aux = -0.5_dp * grid%w(iq)*sum_linewidth_modes(S, sigma(it), freq, bose, V3sq, nu0)
-        lw(:,it) = lw(:,it) + aux
-        IF(present(lw_UN)) lw_UN(:,j_un,it) = lw_UN(:,j_un,it) + aux
-        timer_CALL t_sum%stop()
-      ENDDO
-      !
-    ENDDO
-    !
-      timer_CALL t_mpicom%start()
-    IF(grid%scattered) CALL mpi_bsum(S%nat3,nconf,lw)
-    IF(grid%scattered .and. present(lw_UN)) CALL mpi_bsum(S%nat3,2,nconf,lw_UN)
+      timer_CALL t_freqd%stop()
+      timer_CALL t_thtetra%start()
+      CALL tetra_init(grid%n, S%bg, gather_doubled_X)
+      weights_X = tetra_weights_delta_vec(S%nat3, freq(:,1))
+      CALL tetra_init(grid%n, S%bg, gather_doubled_C)
+      weights_C = tetra_weights_delta_vec(S%nat3, freq(:,1))
 
-      timer_CALL t_mpicom%stop()
-    linewidth_q = lw
-    !
-    DEALLOCATE(U, V3sq, D3)
-    !
-  END FUNCTION linewidth_q  
-  ! <<^V^\\=========================================//-//-//========//O\\//
-  ! This function returns the complex self energy from the bubble(?) diagram:
-  !  its real part is the order contribution to lineshift
-  !  its complex part is the intrinsic linewidth
-  FUNCTION selfnrg_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, freq1, U1)
-    USE q_grids,          ONLY : q_grid
-    USE input_fc,         ONLY : ph_system_info
-    USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
-    USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
-    IMPLICIT NONE
-    !
-    REAL(DP),INTENT(in) :: xq0(3)
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
-    !
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: grid
-    REAL(DP),INTENT(in) :: sigma(nconf) ! ry
-    !
-    REAL(DP),OPTIONAL,INTENT(in) :: freq1(S%nat3)
-    COMPLEX(DP),OPTIONAL,INTENT(in) :: U1(S%nat3,S%nat3)
-    !
-    ! FUNCTION RESULT:
-    COMPLEX(DP) :: selfnrg_q(S%nat3,nconf)
-    COMPLEX(DP) :: se(S%nat3,nconf) ! aux
-    !
-    COMPLEX(DP),ALLOCATABLE :: U(:,:,:), D3(:,:,:)
-    REAL(DP),ALLOCATABLE    :: V3sq(:,:,:)
-    INTEGER :: iq, jq, nu, it
-    INTEGER :: nu0(3)
-    !
-    REAL(DP) :: freq(S%nat3,3), bose(S%nat3,3), xq(3,3)
-    !
-    ALLOCATE(U(S%nat3, S%nat3,3))
-    ALLOCATE(V3sq(S%nat3, S%nat3, S%nat3))
-    ALLOCATE(D3(S%nat3, S%nat3, S%nat3))
-    !
-    se = (0._dp, 0._dp)
-    !
+      timer_CALL t_thtetra%stop()
+      DEALLOCATE(gather_doubled_X, gather_doubled_C)
+   END SUBROUTINE
+
+   PURE function rotate_single_d3(i, j, k, U, D3, invert) result(D3_s2)
+      INTEGER, INTENT(IN) :: i, j, k
+      LOGICAL, INTENT(IN) :: invert
+      COMPLEX(DP), INTENT(IN) :: U(:,:,:), D3(:,:,:)
+      !
+      INTEGER :: a, b, c, nat3
+      COMPLEX(DP) :: D3_s, aux
+      REAL(DP) :: D3_s2
+      D3_s = 0._dp
+      nat3 = SIZE(U, 1)
+      !
+      DO c = 1, nat3
+         DO b = 1, nat3
+            if (invert) then
+               aux = U(b,i,1)* U(c,k,3)
+            else
+               aux = U(b,j,2)* U(c,k,3)
+            endif
+            DO a = 1, nat3
+               if (invert) then
+                  D3_s = D3_s + D3(a,b,c) * CONJG( aux * U(a,j,2) )
+               else
+                  D3_s = D3_s + D3(a,b,c) * CONJG( aux * U(a,i,1) )
+               endif
+            END DO
+         END DO
+      END DO
+      D3_s2 = REAL( CONJG(D3_s)* D3_s, kind=DP)
+   end function
+
+   FUNCTION linewidth_q(xq1, S, fc2, fc3, grid, input, lw_UN)
+      USE functions, ONLY : f_gauss
+      USE fc3_interpolate, ONLY : sum_R3, d3_mixed
+      USE merge_degenerate,   ONLY : merge_degen
+
+      IMPLICIT NONE
+      !! Normal/Umklapp contribution
+      TYPE(q_grid), INTENT(IN) :: grid
+      REAL(DP), INTENT(IN) :: xq1(3)
+      TYPE(ph_system_info), INTENT(IN) :: S
+      TYPE(forceconst2_grid), INTENT(IN) :: fc2
+      CLASS(forceconst3), INTENT(IN) :: fc3
+      TYPE(code_input_type), INTENT(IN) :: input
+      ! LOGICAL, INTENT(IN), OPTIONAL :: coalescence
+      REAL(DP),OPTIONAL,INTENT(out)   :: lw_UN(S%nat3,2,input%nconf) ! Normal/Umklapp contribution
+      !
+      INTEGER,PARAMETER :: normal=1, umklapp=2
+      INTEGER :: iq, jq, j_un, it, nu0(3), i,j,k
+      REAL(DP) :: f(3), xq(3,3), freq(S%nat3,3), bose(S%nat3,3)
+      REAL(DP) :: freqm1(S%nat3,3), freqtotm1_23, freqtotm1, bose_C, bose_X, dom_C, dom_X, sigma
+      COMPLEX(DP) :: aux(S%nat3), linewidth_q(S%nat3,input%nconf)
+      complex(DP) :: U(S%nat3,S%nat3,3), D3(S%nat3,S%nat3,S%nat3)
+      TYPE(d3_mixed) :: Dqr
+      REAL(DP), allocatable :: weights_C(:,:,:), weights_X(:,:,:)
+      ! ALLOCATE(U(S%nat3,S%nat3,3), D3(S%nat3,S%nat3,S%nat3))
+      REAL(DP) :: V3sq(S%nat3,S%nat3,S%nat3), ctm
+      linewidth_q = 0._dp
+      IF(present(lw_UN)) lw_UN = 0._dp
+      !
+      ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q1
       timer_CALL t_freq%start()
-    ! Compute eigenvalues, eigenmodes at q1
-    xq(:,1) = xq0
-    nu0(1) = set_nu0(xq(:,1), S%at)
-    IF(present(freq1) .and. present(U1)) THEN
-      freq(:,1) = freq1
-      U(:,:,1)    = U1
-    ELSE
+      xq(:,1) = xq1
+      nu0(1) = set_nu0(xq(:,1), S%at)
       CALL freq_phq_safe(xq(:,1), S, fc2, freq(:,1), U(:,:,1))
-    ENDIF
-        timer_CALL t_freq%stop()
-    
-    DO iq = 1, grid%nq
-      !
-      timer_CALL t_freq%start()
-      xq(:,2) = grid%xq(:,iq)
-      xq(:,3) = -(xq(:,2)+xq(:,1))
-!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
-      DO jq = 2,3
-        nu0(jq) = set_nu0(xq(:,jq), S%at)
-        CALL freq_phq_safe(xq(:,jq), S, fc2, freq(:,jq), U(:,:,jq))
-      ENDDO
-!$OMP END PARALLEL DO
-        timer_CALL t_freq%stop()
-      !
-        timer_CALL t_fc3int%start()
-      CALL fc3%interpolate(xq(:,2), xq(:,3), S%nat3, D3)
-        timer_CALL t_fc3int%stop()
-        timer_CALL t_fc3rot%start()
-      CALL ip_cart2pat(D3, S%nat3, U(:,:,1), U(:,:,2), U(:,:,3))
-        timer_CALL t_fc3rot%stop()
-        timer_CALL t_fc3m2%start()
-      V3sq = REAL( CONJG(D3)*D3 , kind=DP)
-        timer_CALL t_fc3m2%stop()
-      !
-      DO it = 1,nconf
-        ! Compute bose-einstein occupation at q2 and q3
-          timer_CALL t_bose%start()
-!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
-        DO jq = 1,3
-          CALL bose_phq(T(it),s%nat3, freq(:,jq), bose(:,jq))
-        ENDDO
-!$OMP END PARALLEL DO
-          timer_CALL t_bose%stop()
-        !
-          timer_CALL t_sum%start()
-        se(:,it) = se(:,it) + grid%w(iq)*sum_selfnrg_modes( S, sigma(it), T(it), freq, bose, V3sq, nu0 )
-          timer_CALL t_sum%stop()
-        !
-      ENDDO
-      !
-    ENDDO
-    !
-      timer_CALL t_mpicom%start()
-    IF(grid%scattered) CALL mpi_bsum(S%nat3,nconf,se)
-      timer_CALL t_mpicom%stop()
-    selfnrg_q = -0.5_dp * se
-    !
-    DEALLOCATE(U, V3sq)
-    !
-  END FUNCTION selfnrg_q  
-  ! \/o\________\\\_________________________________________/^>
-  ! Simple spectral function, computed as a superposition of Lorentzian functions
-  FUNCTION simple_spectre_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1, shift) &
-  RESULT(spectralf)
-    USE q_grids,            ONLY : q_grid
-    USE constants,          ONLY : RY_TO_CMM1
-    USE input_fc,           ONLY : ph_system_info
-    USE fc2_interpolate,    ONLY : forceconst2_grid, freq_phq_safe
-    USE fc3_interpolate,    ONLY : forceconst3
-    
-    IMPLICIT NONE
-    ! ARGUMENTS:
-    REAL(DP),INTENT(in) :: xq0(3)
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
-    !
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: grid
-    REAL(DP),INTENT(in) :: sigma(nconf) ! ry
-    INTEGER,INTENT(in)  :: ne
-    REAL(DP),INTENT(in) :: ener(ne)
-    LOGICAL,INTENT(in)  :: shift
-    !
-    REAL(DP),OPTIONAL,INTENT(in) :: freq1(S%nat3)
-    COMPLEX(DP),OPTIONAL,INTENT(in) :: U1(S%nat3,S%nat3)
-    !
-    ! FUNCTION RESULT:
-    REAL(DP) :: spectralf(ne,S%nat3,nconf)
-    !
-    COMPLEX(DP) :: selfnrg(S%nat3,nconf)
-    !
-    INTEGER :: it, i, ie
-    REAL(DP) :: gamma(S%nat3,nconf), delta(S%nat3,nconf), omega, denom
-    COMPLEX(DP) :: U(S%nat3, S%nat3)
-    REAL(DP) :: freq(S%nat3)
-      !
-    ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q1
-    IF(present(freq1) .and. present(U1)) THEN
-      freq = freq1
-      U    = U1
-    ELSE
-      !CALL freq_phq_safe(xq(:,1), S, fc2, freq(:,1), U(:,:,1))
-      CALL freq_phq_safe(xq0, S, fc2, freq, U)
-    ENDIF
-    !
-    ! use lineshift to compute 3rd order linewidth and lineshift
-    IF(shift)THEN
-      selfnrg = selfnrg_q(xq0, nconf, T, sigma, S, grid, fc2, fc3)    
-      gamma(:,:) = -DIMAG(selfnrg(:,:))
-      delta(:,:) =   DBLE(selfnrg(:,:))
-    ELSE
-      gamma = linewidth_q(xq0, nconf, T, sigma, S, grid, fc2, fc3)    
-      delta = 0._dp
-    ENDIF
-    !
-    DO it = 1,nconf
-      WRITE(*,'(30x,6e12.2,5x,6e12.2)') gamma(:,it)*RY_TO_CMM1,delta(:,it)*RY_TO_CMM1
-    ENDDO
-    !
-    delta = 0._dp
-    ! Compute and superpose the Lorentzian functions corresponding to each band
-    DO it = 1,nconf
-      DO i = 1,S%nat3
-        DO ie = 1, ne
-          ! Only apply shift (i.e. real part of self nrg) if requested
-          omega = freq(i)
-          denom =   (ener(ie)**2 -omega**2 -2*omega*delta(i,it))**2 &
-                   + 4*omega**2 *gamma(i,it)**2 
-          IF(ABS(denom)/=0._dp)THEN
-            spectralf(ie,i,it) = 2*omega*gamma(i,it) / denom
-          ELSE
-            spectralf(ie,i,it) = 0._dp
-          ENDIF
-        ENDDO
-      ENDDO
-    ENDDO
-    !
-  END FUNCTION simple_spectre_q  
-
-
-  ! <<^V^\\=========================================//-//-//========//O\\//
-  ! Self energy for all the phonon bands at q in a range of frequencies
-  FUNCTION selfnrg_omega_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1) &
-  RESULT(selfnrg_wq)
-    USE q_grids,          ONLY : q_grid
-    USE input_fc,         ONLY : ph_system_info
-    USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
-    USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
-    !
-    IMPLICIT NONE
-    !
-    REAL(DP),INTENT(in) :: xq0(3)
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
-    !
-    INTEGER,INTENT(in)  :: ne
-    REAL(DP),INTENT(in) :: ener(ne)
-    !
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)           :: grid
-    REAL(DP),INTENT(in)               :: sigma(nconf) ! ry
-    !
-    REAL(DP),OPTIONAL,INTENT(in) :: freq1(S%nat3)
-    COMPLEX(DP),OPTIONAL,INTENT(in) :: U1(S%nat3,S%nat3)
-    !
-    ! To interpolate D2 and D3:
-    INTEGER :: iq, jq, nu, it
-    COMPLEX(DP),ALLOCATABLE :: U(:,:,:), D3(:,:,:)
-    REAL(DP),ALLOCATABLE    :: V3sq(:,:,:)
-    REAL(DP) :: freq(S%nat3,3), bose(S%nat3,3), xq(3,3)
-    !
-    ! To compute the spectral function from the self energy:
-    INTEGER  :: i, ie
-    INTEGER  :: nu0(3)
-    REAL(DP) :: gamma, delta, omega, denom
-    COMPLEX(DP),ALLOCATABLE :: selfnrg(:,:,:)
-    ! FUNCTION RESULT:
-    COMPLEX(DP) :: selfnrg_wq(ne,S%nat3,nconf)
-    !
-    ALLOCATE(U(S%nat3, S%nat3,3))
-    ALLOCATE(V3sq(S%nat3, S%nat3, S%nat3))
-    ALLOCATE(D3(S%nat3, S%nat3, S%nat3))
-    ALLOCATE(selfnrg(ne,S%nat3,nconf))
-    !
-    selfnrg = (0._dp, 0._dp)
-    !
-    ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q1
-      timer_CALL t_freq%start()
-    xq(:,1) = xq0
-    nu0(1) = set_nu0(xq(:,1), S%at)
-    IF(present(freq1) .and. present(U1)) THEN
-      freq(:,1) = freq1
-      U(:,:,1)    = U1
-    ELSE
-      CALL freq_phq_safe(xq(:,1), S, fc2, freq(:,1), U(:,:,1))
-    ENDIF
       timer_CALL t_freq%stop()
-    !
-    DO iq = 1, grid%nq
-      !CALL print_percent_wall(33.333_dp, 300._dp, iq, grid%nq, (iq==1))
-      !
-        timer_CALL t_freq%start()
-      xq(:,2) = grid%xq(:,iq)
-      xq(:,3) = -(xq(:,2)+xq(:,1))
-!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
-      DO jq = 2,3
-        nu0(jq) = set_nu0(xq(:,jq), S%at)
-        CALL freq_phq_safe(xq(:,jq), S, fc2, freq(:,jq), U(:,:,jq))
-      ENDDO
-!$OMP END PARALLEL DO
-        timer_CALL t_freq%stop()
-      !
-      !
-      ! ------ start of CALL scatter_3q(S,fc2,fc3, xq(:,1),xq(:,2),xq(:,3), V3sq)
-        timer_CALL t_fc3int%start()
-      CALL fc3%interpolate(xq(:,2), xq(:,3), S%nat3, D3)
-        timer_CALL t_fc3int%stop()
-        timer_CALL t_fc3rot%start()
-      CALL ip_cart2pat(D3, S%nat3, U(:,:,1), U(:,:,2), U(:,:,3))
-        timer_CALL t_fc3rot%stop()
-        timer_CALL t_fc3m2%start()
-      V3sq = REAL( CONJG(D3)*D3 , kind=DP)
-        timer_CALL t_fc3m2%stop()
-      !
-      DO it = 1,nconf
-        ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q2 and q3
-          timer_CALL t_bose%start()
-!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
-        DO jq = 1,3
-          CALL bose_phq(T(it),s%nat3, freq(:,jq), bose(:,jq))
-        ENDDO
-!$OMP END PARALLEL DO
-          timer_CALL t_bose%stop()
-          timer_CALL t_sum%start()
-        selfnrg(:,:,it) = selfnrg(:,:,it) + grid%w(iq)*sum_selfnrg_spectre( S, sigma(it), freq, bose, V3sq, ne, ener, nu0 )
-          timer_CALL t_sum%stop()
-        !
-      ENDDO
-      !
-    ENDDO
-    !
-      timer_CALL t_mpicom%start()
-    IF(grid%scattered) CALL mpi_bsum(ne,S%nat3,nconf,selfnrg)
-      timer_CALL t_mpicom%stop()
-    selfnrg_wq = -0.5_dp * selfnrg
-    !
-    DEALLOCATE(U, V3sq, D3, selfnrg)
-    !
-  END FUNCTION selfnrg_omega_q
-  !
-  ! <<^V^\\=========================================//-//-//========//O\\//
-  ! Spectral weight function, computed as in eq. 1 of arXiv:1312.7467v1
-  FUNCTION spectre_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1, shift) &
-  RESULT(spectralf)
-    USE q_grids,          ONLY : q_grid
-    USE input_fc,         ONLY : ph_system_info
-    USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
-    USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
-    !
-    IMPLICIT NONE
-    !
-    REAL(DP),INTENT(in) :: xq0(3)
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
-    !
-    INTEGER,INTENT(in)  :: ne
-    REAL(DP),INTENT(in) :: ener(ne)
-    !
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: grid
-    REAL(DP),INTENT(in) :: sigma(nconf) ! ry
-    LOGICAL,INTENT(in)  :: shift ! set to false to drop the real part of the self-energy
-    !
-    REAL(DP),INTENT(in) :: freq1(S%nat3)
-    COMPLEX(DP),INTENT(in) :: U1(S%nat3,S%nat3)
-    !
-    ! To compute the spectral function from the self energy:
-    INTEGER  :: i, ie, it
-    INTEGER  :: nu0(3)
-    REAL(DP) :: gamma, delta, omega, denom
-    COMPLEX(DP) :: selfnrg(ne,S%nat3,nconf)
-    ! FUNCTION RESULT:
-    REAL(DP)    :: spectralf(ne,S%nat3,nconf)
-    !
-    ! Once we have the self-energy, the rest is trivial
-    selfnrg = selfnrg_omega_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1)
-    !
-      timer_CALL t_mkspf%start()
-    DO it = 1,nconf
-      DO i = 1,S%nat3
-        DO ie = 1, ne
-          gamma =  -DIMAG(selfnrg(ie,i,it))
-          IF(shift) THEN
-            delta =   DBLE(selfnrg(ie,i,it))
-          ELSE
-            delta = 0._dp
-          ENDIF
-          omega = freq1(i)
-          denom =   (ener(ie)**2 -omega**2 -2*omega*delta)**2 &
-                   + 4*omega**2 *gamma**2 
-          IF(ABS(denom)/=0._dp)THEN
-            spectralf(ie,i,it) = 2*omega*gamma / denom
-          ELSE
-            spectralf(ie,i,it) = 0._dp
-          ENDIF
-        ENDDO
-      ENDDO
-    ENDDO
-      timer_CALL t_mkspf%stop()
-    !
-  END FUNCTION spectre_q
 
-  ! <<^V^\\=========================================//-//-//========//O\\//
-  ! Spectral weight function, computed as in eq. 1 of arXiv:1312.7467v1
-  ! test, compute this as imahinary part of epsilon(omega)
-  FUNCTION spectre2_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1) &
-  RESULT(spectralf)
-    USE q_grids,          ONLY : q_grid
-    USE input_fc,         ONLY : ph_system_info
-    USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
-    USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
-    !
-    IMPLICIT NONE
-    !
-    REAL(DP),INTENT(in) :: xq0(3)
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
-    !
-    INTEGER,INTENT(in)  :: ne
-    REAL(DP),INTENT(in) :: ener(ne)
-    !
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: grid
-    REAL(DP),INTENT(in) :: sigma(nconf) ! ry
-    !LOGICAL,INTENT(in)  :: shift ! set to false to drop the real part of the self-energy
-    !
-    REAL(DP),INTENT(in) :: freq1(S%nat3)
-    COMPLEX(DP),INTENT(in) :: U1(S%nat3,S%nat3)
-    !
-    ! To compute the spectral function from the self energy:
-    INTEGER  :: i, ie, it
-    INTEGER  :: nu0(3)
-    REAL(DP) :: gamma, delta, omega, denom
-    COMPLEX(DP) :: tepsilon(ne,S%nat3,nconf)
-    ! FUNCTION RESULT:
-    REAL(DP)    :: spectralf(ne,S%nat3,nconf)
-    !
-    ! Once we have the self-energy, the rest is trivial
-    tepsilon = tepsilon_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1)
-    !
-      timer_CALL t_mkspf%start()
-    DO it = 1,nconf
-      DO i = 1,S%nat3
-        DO ie = 1,ne
-          !IF(freq1(i)/=0._dp)THEN
-            spectralf(ie,i,it) = DIMAG(tepsilon(ie,i,it))
-          !ELSE
-          !  spectralf(ie,i,it) = 0._dp
-          !ENDIF
-        ENDDO
+      !> for a two step interpolation to be effective, we need to calculate
+      !> fc3%interpolate on xq1 and xq2/xq3. I chose fc3%interpolate(xq1,xq3),
+      !> so xq2 and xq1 are inverted then (in ip_cart2pat and in V3sq(j,i,k))
+      CALL fc3%sum_R2(xq(:,1), S%nat3, Dqr)
+
+      if (input%delta_approx == 'tetra') then
+         allocate(weights_C(S%nat3, S%nat3**2, grid%nqtot))
+         allocate(weights_X(S%nat3, S%nat3**2, grid%nqtot))
+         CALL weights_tetra(grid, xq1, S, fc2, weights_C, weights_X)
+      endif
+
+      DO iq = 1, grid%nq
+         !
+         timer_CALL t_freq%start()
+         ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q2 and q3
+         !  IF(PRESENT(coalescence)) THEN
+         !  xq(:,2) = grid%xq(:,iq)
+         !     xq(:,3) = -(xq(:,2)+xq(:,1))
+         !  ELSE
+         ! xq(:,2) = [0.5, 0.4, 0.3]
+         xq(:,2) = grid%xq(:,iq)
+         xq(:,3) = - (xq(:,1) + xq(:,2))
+         !  ENDIF
+         IF(present(lw_UN)) THEN
+            IF(ALL(ABS(refold_bz(xq(:,1), S%bg) &
+               +refold_bz(xq(:,2), S%bg) &
+               +refold_bz(xq(:,3), S%bg))<1.d-6)) THEN
+               j_un = normal
+               j_un = umklapp
+            ENDIF
+         ENDIF
+
+!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
+         DO jq = 2,3
+            nu0(jq) = set_nu0(xq(:,jq), S%at)
+            CALL freq_phq_safe(xq(:,jq), S, fc2, freq(:,jq), U(:,:,jq))
+         ENDDO
+!$OMP END PARALLEL DO
+         timer_CALL t_freq%stop()
+         !
+         timer_CALL t_fc3int%start()
+         ! old implementation of interpolation:
+         ! CALL fc3%interpolate(xq(:,2), xq(:,3), S%nat3, D3)
+         CALL sum_R3(S, xq(:,3), Dqr, D3)
+         timer_CALL t_fc3int%stop()
+         timer_CALL t_fc3rot%start()
+         !> gemm implementation of rotation
+         CALL ip_cart2pat_gemm(D3, S%nat3, U(:,:,2), U(:,:,1), U(:,:,3))
+         timer_CALL t_fc3rot%stop()
+         timer_CALL t_fc3m2%start()
+         V3sq = REAL( CONJG(D3)*D3 , kind=DP)
+         timer_CALL t_fc3m2%stop()
+         DO it = 1,input%nconf
+            timer_CALL t_bose%start()
+            ! Compute bose-einstein occupation at q2 and q3
+!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
+            DO jq = 1,3
+               CALL bose_phq(input%T(it),S%nat3, freq(:,jq), bose(:,jq))
+            ENDDO
+!$OMP END PARALLEL DO
+            timer_CALL t_bose%stop()
+            timer_CALL t_sum%start()
+            freqm1 = 0._dp
+            aux = 0._dp
+            DO i = 1,S%nat3
+               do j = 1,3
+                  IF(i>=nu0(j)) freqm1(i,j) = 0.5_dp/freq(i,j)
+               ENDDO
+            ENDDO
+!$OMP PARALLEL DO DEFAULT(SHARED) &
+!$OMP             PRIVATE(i,j,k,bose_C,bose_X,dom_C,dom_X,ctm_C,ctm_X,&
+!$OMP                     freqtotm1_23,freqtotm1) &
+!$OMP             REDUCTION(+: aux) COLLAPSE(2)
+            DO j = 1,S%nat3
+               DO k = 1,S%nat3
+                  !
+                  bose_C = 2* (bose(j,2) - bose(k,3))
+                  bose_X = bose(j,2) + bose(k,3) + 1
+                  freqtotm1_23= freqm1(j,2) * freqm1(k,3)
+                  !
+                  DO i = 1,S%nat3
+                     !  IF(input%calculation == "cgp" .or. input%calculation == "exact") THEN
+                     !     bose_C = bose(i,1) * bose(j,2) * (bose(k,3)+1)
+                     !     bose_X = (bose(i,1)+1) * bose(j,2) * bose(k,3) / 2
+                     !  ENDIF
+                     !
+                     !sigma_= MIN(sigma, 0.5_dp*MAX(MAX(freq(i,1), freq(j,2)), freq(k,3)))
+                     !
+                     freqtotm1 = freqm1(i,1) * freqtotm1_23
+                     !IF(freqtot/=0._dp)THEN
+                     !
+                     sigma = input%sigma(it)/RY_TO_CMM1
+                     SELECT CASE(input%delta_approx)
+                      CASE ("gauss")
+                        dom_C =(freq(i,1)+freq(j,2)-freq(k,3))
+                        dom_X =(freq(i,1)-freq(j,2)-freq(k,3))
+                        ctm = bose_C * f_gauss(dom_C, sigma) + bose_X * f_gauss(dom_X, sigma)
+                      CASE ("tetra")
+                        ctm = bose_C * weights_C(i, S%nat3*(j-1) + k, iq+grid%iq0) + &
+                        & bose_X * weights_X(i, S%nat3*(j-1) + k, iq+grid%iq0)
+                        ! CASE ("selfnrg")
+                        !   f(1) = freq(i,1)
+                        !   f(2) = freq(j,2)
+                        !   f(3) = freq(k,3)
+                        !   ctm = ctm_selfnrg(sigma, input%T(it), f, bose_C, bose_X)
+                        ! CASE ("selfnrg_sp")
+                        !   f(1) = freq(i,1)
+                        !   f(2) = freq(j,2)
+                        !   f(3) = freq(k,3)
+                        !   ctm = ctm_selfnrg_spectre(sigma, f, energy, bose_C, bose_X)
+                        !  CASE("cgp_C")
+                        !   !> the prefactor 2 is to annul the 1/2 in the definition of the linewidth, but maybe
+                        !   !> there's another prefactor
+                        !   ctm = 2 * bose(i,1) * bose(j,2) * (1.0_dp + bose(k,3)) * weights_C(i,S%nat3*(j-1) + k, iq)
+                      CASE DEFAULT
+                        CALL errore("sum_rotate_lw", "you should give sigma/tetra_weights", 1)
+                     END SELECT
+                     !
+                     ! IF(TRIM(input%calculation) == "cgp" .or. TRIM(input%calculation) == "exact") THEN
+                     !   ctm = ctm * 2 * bose(i,1) * (bose(i,1) + 1)
+                     ! ENDIF
+                     ! IF(REAL(ctm, DP) < 1) CYCLE
+                     ! ci sono tanti negativi che contribuiscono sulla terza cifra, mica da poco
+                     !
+                     !> rotation of single D3 only where we know that we have scattering
+                     timer_CALL t_fc3rot%start()
+                     ! V3sq = rotate_single_d3(i,j,k, U, D3, invert=.true.)
+
+                     aux(i) = aux(i) + ctm * V3sq(j,i,k) * freqtotm1
+                     ! if (i == 3 .and. j == 4 .and. k == 2 .and. iq == 6) then
+                     !    print*, ctm, V3sq(j,i,k), freqtotm1
+                     ! endif
+                     timer_CALL t_fc3rot%stop()
+                  ENDDO
+               ENDDO
+            ENDDO
+!$OMP END PARALLEL DO
+            !
+            CALL merge_degen(S%nat3, aux, freq(:,1))
+
+            linewidth_q(:,it) = linewidth_q(:,it) + aux * grid%w(iq)
+            IF(present(lw_UN)) lw_UN(:,j_un,it) = lw_UN(:,j_un,it) + aux
+            timer_CALL t_sum%stop()
+         ENDDO
+         !
       ENDDO
-    ENDDO
-      timer_CALL t_mkspf%stop()
-    !
-  END FUNCTION spectre2_q  
-  !
-  ! <<^V^\\=========================================//-//-//========//O\\//
-  !  Complex \tilde{epsilon} in a range of frequencies
-  ! Experimental subroutine, assumes the material cubic and takes
-  ! epsilon(1,1) as epsilon_infty
-  FUNCTION tepsilon_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1) &
-  RESULT(tepsilon)
-    USE q_grids,          ONLY : q_grid
-    USE input_fc,         ONLY : ph_system_info
-    USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
-    USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
-    USE constants,        ONLY : fpi
-    !
-    IMPLICIT NONE
-    !
-    REAL(DP),INTENT(in) :: xq0(3)
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
-    !
-    INTEGER,INTENT(in)  :: ne
-    REAL(DP),INTENT(in) :: ener(ne)
-    !
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: grid
-    REAL(DP),INTENT(in) :: sigma(nconf) ! ry
-    !
-    REAL(DP),INTENT(in) :: freq1(S%nat3)
-    COMPLEX(DP),INTENT(in) :: U1(S%nat3,S%nat3)
-    !
-    ! To compute the spectral function from the self energy:
-    INTEGER  :: i, ie, it, j
-    INTEGER  :: nu0(3)
-    REAL(DP) :: pref, epsilon_infty, rmass, zeu_i2
-    COMPLEX(DP) :: denom
-    COMPLEX(DP):: selfnrg(ne,S%nat3,nconf)
-    ! FUNCTION RESULT:
-    COMPLEX(DP)    :: tepsilon(ne,S%nat3,nconf)
-    ! 
-    IF(.not.S%lrigid) CALL errore("tepsilon","Cannot compute \tilde{epsilon} without epsilon0", 1)
-    ioWRITE(*,*) "BEWARE: tepsilon is only isotropic"
-    ! 
-    ! Once we have the self-energy, the rest is trivial
-    selfnrg = selfnrg_omega_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1)
-    !
-    ! S = 4piZ^2/(volume mass omega0^2)
-    
-    rmass = S%amass(1)*S%amass(2)/(S%amass(1)+S%amass(2))
-    epsilon_infty = S%epsil(1,1)
-    zeu_i2        = S%zeu(1,1,1)**2
-    pref =  fpi * zeu_i2 /(S%omega * rmass)
-    !pref = 1/freq1(i)**2 ! 4 pi Z^2  / (Volume mu  omega0^2) # mu = reduced mass
-!     print*, "rmass", rmass, S%amass(1:2)
-!     print*, "epsilon", epsilon_infty
-!     print*, "zeu2", zeu_i2
-!     print*, "pref", pref
-!     print*, "vol", S%omega 
-!     print*, "denom", rmass*S%omega
-!     print*, "fpi * zeu_i2", fpi * zeu_i2
-!  denom   1002568.9328649712     
-!  epsilon   3.1410114605330000     
-!  fpi * zeu_i2   48.024054760187823     
-!  pref   4.7901000306236137E-005
-!  rmass   8793.6751743770546        22152.652305024902        14582.196429874200     
-!  vol   114.01023041950073     
-!  zeu2   3.8216328511998792 
-!  
-      timer_CALL t_mkspf%start()
-    tepsilon = DCMPLX(0._dp, 0._dp)
-    DO it = 1,nconf
-      DO i = 1,S%nat3
-        IF(freq1(i)==0._dp) CYCLE
-        DO ie = 1,ne
-          denom = freq1(i)**2 - ener(ie)**2 - 2*freq1(i)*selfnrg(ie,i,it)
-          IF(denom==DCMPLX(0._dp,0._dp)) CYCLE
-          !tepsilon(ie,i,it) = 1 + pref*freq1(i)**2/denom
-          tepsilon(ie,i,it) = epsilon_infty + pref/denom
-        ENDDO
-      ENDDO
-    ENDDO
-      timer_CALL t_mkspf%stop()
-    !
-  END FUNCTION tepsilon_q
-  !
-  ! <<^V^\\=========================================//-//-//========//O\\//
-  ! Infra red reflectivity |sqrt(epsilon)+1/sqrt(epsilon)-1|^2
-  ! Experimental! Assumes isoropic material and a bunch of other stuff
-  FUNCTION ir_reflectivity_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1) &
-  RESULT(reflectivity)
-    USE q_grids,          ONLY : q_grid
-    USE input_fc,         ONLY : ph_system_info
-    USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
-    USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
-    !
-    IMPLICIT NONE
-    !
-    REAL(DP),INTENT(in) :: xq0(3)
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
-    !
-    INTEGER,INTENT(in)  :: ne
-    REAL(DP),INTENT(in) :: ener(ne)
-    !
-    TYPE(forceconst2_grid),INTENT(in) :: fc2
-    CLASS(forceconst3),INTENT(in)     :: fc3
-    TYPE(ph_system_info),INTENT(in)   :: S
-    TYPE(q_grid),INTENT(in)      :: grid
-    REAL(DP),INTENT(in) :: sigma(nconf) ! ry
-    !
-    REAL(DP),INTENT(in) :: freq1(S%nat3)
-    COMPLEX(DP),INTENT(in) :: U1(S%nat3,S%nat3)
-    !
-    ! To compute the spectral function from the self energy:
-    INTEGER  :: i, ie, it
-    INTEGER  :: nu0(3)
-    REAL(DP) :: gamma, delta, omega, denom
-    COMPLEX(DP) :: tepsilon(ne,S%nat3,nconf)
-    COMPLEX(DP) :: aux(ne),aux2(ne)
-    ! FUNCTION RESULT:
-    REAL(DP)    :: reflectivity(ne,S%nat3,nconf)
-    !
-    ! We use tilde{epsilon}, which itself comes from the self-energy
-    tepsilon = tepsilon_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1)
-    !
-      timer_CALL t_mkspf%start()
-    DO it = 1,nconf
-      DO i = 1,S%nat3
-        aux  = SQRT(tepsilon(:,i,it))
-        aux2 = (aux-1)/(aux+1)
-        reflectivity(:,i,it) = DBLE(aux2*CONJG(aux2))
-      ENDDO
-    ENDDO
-      timer_CALL t_mkspf%stop()
-    !
-  END FUNCTION ir_reflectivity_q
-  !
-  ! Sum the self energy at the provided ener(ne) input energies
-  ! \/o\________\\\_________________________________________/^>
-  FUNCTION sum_selfnrg_spectre(S, sigma, freq, bose, V3sq, ne, ener, nu0)
-    USE input_fc,           ONLY : ph_system_info
-    USE merge_degenerate,   ONLY : merge_degen
-    USE functions,          ONLY : sigma_mgo
-    IMPLICIT NONE
-    TYPE(ph_system_info),INTENT(in)   :: S
-    REAL(DP),INTENT(in) :: sigma   ! smearing (regularization) (Ry)
-    REAL(DP),INTENT(in) :: freq(S%nat3,3)  ! phonon energies (Ry)
-    REAL(DP),INTENT(in) :: bose(S%nat3,3)  ! bose/einstein distribution of freq
-    REAL(DP),INTENT(in) :: V3sq(S%nat3,S%nat3,S%nat3) ! |D^3|**2 on the basis of phonons patterns
-    !
-    INTEGER,INTENT(in)  :: ne           ! number of energies...
-    REAL(DP),INTENT(in) :: ener(ne)     ! energies for which to compute the spectral function
-    INTEGER,INTENT(in)  :: nu0(3)       ! first non-zero phomnon frequency
-    !
-    ! _P -> scattering, _M -> cohalescence
-    REAL(DP) :: bose_P, bose_M      ! final/initial state populations 
-    REAL(DP) :: factor, sigma_, T=0._dp !freqtotm1
-    REAL(DP) :: omega_P,  omega_M   ! \delta\omega
-    REAL(DP) :: omega_P2, omega_M2  ! \delta\omega
-    COMPLEX(DP) :: ctm_P,ctm_M, reg, num
-    COMPLEX(DP) :: ctm(ne)
-    REAL(DP)    :: freqm1(S%nat3,3)  ! phonon energies (Ry)
-    !
-    INTEGER :: i,j,k, ie
-    !
-    ! Note: using the function result in an OMP reduction causes crash with ifort 14
-    COMPLEX(DP) :: sum_selfnrg_spectre(ne,S%nat3)
-    COMPLEX(DP),ALLOCATABLE :: spf(:,:)
-    !
+
+      timer_CALL t_mpicom%start()
+      IF(grid%scattered) CALL mpi_bsum(S%nat3,input%nconf,linewidth_q)
+      IF(grid%scattered .and. present(lw_UN)) CALL mpi_bsum(S%nat3,2,input%nconf,lw_UN)
+      timer_CALL t_mpicom%stop()
+
+      linewidth_q = linewidth_q * pi / 2
+      if (input%delta_approx == 'tetra') linewidth_q = linewidth_q * grid%nqtot
+
+      if(allocated(weights_C)) deallocate(weights_C, weights_X)
+
+
+   END FUNCTION
+
+   !> helper function for selfnrg. Not tesed, not used. It would be nice to use 
+   !> only linewidth_q and various ctm functions for each case
+   FUNCTION ctm_selfnrg_spectre(sigma, freq, ener, bose_C, bose_X)
+      USE input_fc,           ONLY : ph_system_info
+      USE merge_degenerate,   ONLY : merge_degen
+      USE functions,          ONLY : sigma_mgo
+      IMPLICIT NONE
+      REAL(DP),INTENT(in) :: sigma   ! smearing (regularization) (Ry)
+      REAL(DP),INTENT(in) :: freq(3)  ! phonon energies (Ry)
+      !
+      REAL(DP),INTENT(in) :: ener     ! energies for which to compute the spectral function
+      REAL(DP), INTENT(IN) :: bose_C, bose_X
+      !
+      ! _P -> scattering, _M -> cohalescence
+      REAL(DP) :: omega_P,  omega_M   ! \delta\omega
+      REAL(DP) :: omega_P2, omega_M2  ! \delta\omega
+      COMPLEX(DP) :: ctm_P,ctm_M, reg
+      !
+      ! Note: using the function result in an OMP reduction causes crash with ifort 14
+      COMPLEX(DP) :: ctm_selfnrg_spectre
+      !
 !     IF(sigma<=0._dp)THEN
 !       CALL errore("sum_selfnrg_spectre","spf not implemented in the static limit. "&
 !                   //"NEW: To do unshifted spf use 'spf imag'",1)
 !     ENDIF
-    !
-    ALLOCATE(spf(ne,S%nat3))
-    spf = (0._dp, 0._dp)
-    !
-    DO i = 1,S%nat3
-      IF(i>=nu0(1)) freqm1(i,1) = 0.5_dp/freq(i,1)
-      IF(i>=nu0(2)) freqm1(i,2) = 0.5_dp/freq(i,2)
-      IF(i>=nu0(3)) freqm1(i,3) = 0.5_dp/freq(i,3)    
-    ENDDO
-    !
+      !
+      !
+      omega_P  = freq(2)+freq(3)
+      omega_P2 = omega_P**2
+      !
+      omega_M  = freq(2)-freq(3)
+      omega_M2 = omega_M**2
+      !
+      !
+      reg = CMPLX(ener, sigma, kind=DP)**2
+      !
+      ctm_P = 2 * bose_C *omega_P/(omega_P2-reg)
+      ctm_M = 2 * bose_X *omega_M/(omega_M2-reg)
+      !
+      ctm_selfnrg_spectre = ctm_P + ctm_M
+      !
+   END FUNCTION
+
+!
+! \/o\________\\\_________________________________________/^>
+! Sum the self energy in a range of frequencies
+   FUNCTION ctm_selfnrg(sigma, T, freq, bose_C, bose_X)
+      USE input_fc,           ONLY : ph_system_info
+      USE functions,          ONLY : df_bose
+      USE merge_degenerate,   ONLY : merge_degen
+      USE functions,          ONLY : sigma_mgo
+      IMPLICIT NONE
+      REAL(DP),INTENT(in) :: sigma, T, freq(3), bose_C, bose_X
+      REAL(DP) :: omega_X,  omega_C   ! \sigma\omega
+      COMPLEX(DP) :: ctm_X, ctm_C, reg, ctm_selfnrg
+      !
+      ctm_X = 0._dp
+      ctm_C = 0._dp
+      omega_X  = freq(2)+freq(3)
+      omega_C  = freq(2)-freq(3)
+      IF(sigma>0._dp)THEN
+         reg = CMPLX(freq(1), sigma, kind=DP)**2
+         ctm_X = 2 * bose_X *omega_X/(omega_X**2-reg )
+         ctm_C = 2 * bose_C *omega_C/(omega_C**2-reg )
+         ctm_X = 2 * bose_X *omega_X/(omega_X**2+sigma**2)
+         ctm_C = 2 * bose_C *omega_C/(omega_C**2+sigma**2)
+         ! In the static limit with sigma=0 case we have to take the
+         ! derivative of (n_3-n2)/(w_2-w_3) when w_2 is close to w_3
+         IF(omega_X>0._dp)THEN
+            ctm_X = 2 * bose_X /omega_X
+            ctm_X = 0._dp
+         ENDIF
+         !
+         IF(ABS(omega_C)>1.e-5_dp)THEN
+            ctm_C = 2 * bose_C /omega_C
+            IF(T>0._dp)THEN
+               ctm_C = -2* df_bose(0.5_dp * omega_X, T)
+               ctm_C = 0._dp
+            ENDIF
+         ENDIF
+         !
+      ENDIF
+
+      ctm_selfnrg = ctm_C + ctm_X
+   END FUNCTION
+!
+!    FUNCTION sum_rotate_lw(S, freq, bose, D3, U, nu0, calc, sigma, T, weights_C, weights_X)
+!       USE functions, ONLY : f_gauss => f_gauss
+!       USE constants, ONLY : pi, RY_TO_CMM1
+!       USE input_fc,           ONLY : ph_system_info
+!       USE merge_degenerate,   ONLY : merge_degen
+!       IMPLICIT NONE
+!       TYPE(ph_system_info),INTENT(in)   :: S
+!       REAL(DP),INTENT(in) :: freq(S%nat3,3), bose(S%nat3,3)
+!       COMPLEX(DP),INTENT(in) :: D3(S%nat3,S%nat3,S%nat3), U(S%nat3,S%nat3,3)
+!       INTEGER,INTENT(in)  :: nu0(3)
+!       CHARACTER(10), INTENT(IN) :: calc
+!       REAL(DP),INTENT(in), OPTIONAL :: sigma, T
+!       REAL(DP), INTENT(IN), OPTIONAL :: weights_C(S%nat3,S%nat3**2), weights_X(S%nat3,S%nat3**2)
+!       !
+!       COMPLEX(DP) :: sum_rotate_lw(S%nat3)
+!       COMPLEX(DP) :: D3_s
+!       REAL(DP) :: D3_s2
+!       INTEGER :: a,b,c
+!       !
+!       ! _C -> scattering, _X -> cohalescence
+!       REAL(DP) :: bose_C, bose_X ! final/initial state populations
+!       REAL(DP) :: dom_C, dom_X   ! \delta\omega
+!       COMPLEX(DP) :: ctm   !
+!       REAL(DP) :: freqtotm1, freqtotm1_23
+!       REAL(DP) :: freqm1(S%nat3,3)
+!       COMPLEX(DP) ::  aux
+!       !REAL(DP),SAVE :: leftover_e
+!       !
+!       INTEGER :: i,j,k
+!       !
+!       freqm1 = 0._dp
+!       sum_rotate_lw = 0._dp
+!       DO i = 1,S%nat3
+!          IF(i>=nu0(1)) freqm1(i,1) = 0.5_dp/freq(i,1)
+!          IF(i>=nu0(2)) freqm1(i,2) = 0.5_dp/freq(i,2)
+!          IF(i>=nu0(3)) freqm1(i,3) = 0.5_dp/freq(i,3)
+!       ENDDO
+! !$OMP PARALLEL DO DEFAULT(SHARED) &
+! !$OMP             PRIVATE(i,j,k,bose_C,bose_X,dom_C,dom_X,ctm_C,ctm_X,&
+! !$OMP                     freqtotm1_23,freqtotm1) &
+! !$OMP             REDUCTION(+: sum_rotate_lw) COLLAPSE(2)
+!       DO k = 1,S%nat3
+!          DO j = 1,S%nat3
+!             !
+!             bose_C = 2* (bose(j,2) - bose(k,3))
+!             bose_X = bose(j,2) + bose(k,3) + 1
+!             freqtotm1_23= freqm1(j,2) * freqm1(k,3)
+!             !
+!             DO i = 1,S%nat3
+!                !
+!                !sigma_= MIN(sigma, 0.5_dp*MAX(MAX(freq(i,1), freq(j,2)), freq(k,3)))
+!                !
+!                freqtotm1 = freqm1(i,1) * freqtotm1_23
+!                !IF(freqtot/=0._dp)THEN
+!                !
+!                SELECT CASE (calc)
+!                 CASE ("gauss")
+!                   dom_C =(freq(i,1)+freq(j,2)-freq(k,3))
+!                   dom_X =(freq(i,1)-freq(j,2)-freq(k,3))
+!                   ctm = (bose_C * f_gauss(dom_C, sigma) + bose_X * f_gauss(dom_X, sigma))
+!                 CASE ("tetra")
+!                   ctm = bose_C * weights_C(i,S%nat3*(j-1) + k) + bose_X * weights_X(i,S%nat3*(j-1) + k)
+!                 CASE ("selfnrg")
+!                   ctm = ctm_selfnrg(sigma, T, freq, bose_C, bose_X)
+!                 CASE DEFAULT
+!                   CALL errore("sum_rotate_lw", "you should give sigma/tetra_weights", 1)
+!                END SELECT
+!                ! IF(REAL(ctm, DP) < 1) CYCLE
+!                ! ci sono tanti negativi che contribuiscono sulla terza cifra, mica da poco
+!                !
+!                timer_CALL t_fc3rot%start()
+!                !> rotation of single D3 only where we know that we have scattering
+!                D3_s = 0._dp
+!                DO c = 1, S%nat3
+!                   DO b = 1, S%nat3
+!                      aux = U(b,i,1)* U(c,k,3)
+!                      DO a = 1, S%nat3
+!                         D3_s = D3_s + D3(a,b,c) * CONJG( aux * U(a,j,2) )
+!                      END DO
+!                   END DO
+!                END DO
+!                timer_CALL t_fc3rot%stop()
+!                D3_s2 = REAL( CONJG(D3_s)* D3_s, kind=DP)
+!                sum_rotate_lw(i) = sum_rotate_lw(i) + ctm * D3_s2 * freqtotm1
+!             ENDDO
+!          ENDDO
+!       ENDDO
+! !$OMP END PARALLEL DO
+!       !
+!       CALL merge_degen(S%nat3, sum_rotate_lw, freq(:,1))
+!       !
+!    END FUNCTION sum_rotate_lw
+! <<^V^\\=========================================//-//-//========//O\\//
+
+   ! <<^V^\\=========================================//-//-//========//O\\//
+   ! This function returns the complex self energy from the bubble(?) diagram:
+   !  its real part is the order contribution to lineshift
+   !  its complex part is the intrinsic linewidth
+   FUNCTION selfnrg_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, freq1, U1)
+      USE q_grids,          ONLY : q_grid
+      USE input_fc,         ONLY : ph_system_info
+      USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
+      USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
+      IMPLICIT NONE
+      !
+      REAL(DP),INTENT(in) :: xq0(3)
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
+      !
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in)     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: grid
+      REAL(DP),INTENT(in) :: sigma(nconf) ! ry
+      !
+      REAL(DP),OPTIONAL,INTENT(in) :: freq1(S%nat3)
+      COMPLEX(DP),OPTIONAL,INTENT(in) :: U1(S%nat3,S%nat3)
+      !
+      ! FUNCTION RESULT:
+      COMPLEX(DP) :: selfnrg_q(S%nat3,nconf)
+      COMPLEX(DP) :: se(S%nat3,nconf) ! aux
+      !
+      COMPLEX(DP),ALLOCATABLE :: U(:,:,:), D3(:,:,:)
+      REAL(DP),ALLOCATABLE    :: V3sq(:,:,:)
+      INTEGER :: iq, jq, it
+      INTEGER :: nu0(3)
+      !
+      REAL(DP) :: freq(S%nat3,3), bose(S%nat3,3), xq(3,3)
+      !
+      ALLOCATE(U(S%nat3, S%nat3,3))
+      ALLOCATE(V3sq(S%nat3, S%nat3, S%nat3))
+      ALLOCATE(D3(S%nat3, S%nat3, S%nat3))
+      !
+      se = (0._dp, 0._dp)
+      !
+      timer_CALL t_freq%start()
+      ! Compute eigenvalues, eigenmodes at q1
+      xq(:,1) = xq0
+      nu0(1) = set_nu0(xq(:,1), S%at)
+      IF(present(freq1) .and. present(U1)) THEN
+         freq(:,1) = freq1
+         U(:,:,1)    = U1
+      ELSE
+         CALL freq_phq_safe(xq(:,1), S, fc2, freq(:,1), U(:,:,1))
+      ENDIF
+      timer_CALL t_freq%stop()
+
+      DO iq = 1, grid%nq
+         !
+         timer_CALL t_freq%start()
+         xq(:,2) = grid%xq(:,iq)
+         xq(:,3) = -(xq(:,2)+xq(:,1))
+!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
+         DO jq = 2,3
+            nu0(jq) = set_nu0(xq(:,jq), S%at)
+            CALL freq_phq_safe(xq(:,jq), S, fc2, freq(:,jq), U(:,:,jq))
+         ENDDO
+!$OMP END PARALLEL DO
+         timer_CALL t_freq%stop()
+         !
+         timer_CALL t_fc3int%start()
+         CALL fc3%interpolate(xq(:,2), xq(:,3), S%nat3, D3)
+         timer_CALL t_fc3int%stop()
+         timer_CALL t_fc3rot%start()
+         CALL ip_cart2pat(D3, S%nat3, U(:,:,1), U(:,:,2), U(:,:,3))
+         timer_CALL t_fc3rot%stop()
+         timer_CALL t_fc3m2%start()
+         V3sq = REAL( CONJG(D3)*D3 , kind=DP)
+         timer_CALL t_fc3m2%stop()
+         !
+         DO it = 1,nconf
+            ! Compute bose-einstein occupation at q2 and q3
+            timer_CALL t_bose%start()
+!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
+            DO jq = 1,3
+               CALL bose_phq(T(it),s%nat3, freq(:,jq), bose(:,jq))
+            ENDDO
+!$OMP END PARALLEL DO
+            timer_CALL t_bose%stop()
+            !
+            timer_CALL t_sum%start()
+            se(:,it) = se(:,it) + grid%w(iq)*sum_selfnrg_modes( S, sigma(it), T(it), freq, bose, V3sq, nu0 )
+            timer_CALL t_sum%stop()
+            !
+         ENDDO
+         !
+      ENDDO
+      !
+      timer_CALL t_mpicom%start()
+      IF(grid%scattered) CALL mpi_bsum(S%nat3,nconf,se)
+      timer_CALL t_mpicom%stop()
+      selfnrg_q = -0.5_dp * se
+      !
+      DEALLOCATE(U, V3sq)
+      !
+   END FUNCTION selfnrg_q
+   ! \/o\________\\\_________________________________________/^>
+   ! Simple spectral function, computed as a superposition of Lorentzian functions
+   FUNCTION simple_spectre_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1, shift, input) &
+      RESULT(spectralf)
+      USE q_grids,            ONLY : q_grid
+      USE constants,          ONLY : RY_TO_CMM1
+      USE input_fc,           ONLY : ph_system_info
+      USE fc2_interpolate,    ONLY : forceconst2_grid, freq_phq_safe
+      USE fc3_interpolate,    ONLY : forceconst3
+      ! USE globals,            ONLY : g_input
+
+      IMPLICIT NONE
+      ! ARGUMENTS:
+      REAL(DP),INTENT(in) :: xq0(3)
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
+      !
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in)     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: grid
+      type(code_input_type),INTENT(in) :: input
+      REAL(DP),INTENT(in) :: sigma(nconf) ! ry
+      INTEGER,INTENT(in)  :: ne
+      REAL(DP),INTENT(in) :: ener(ne)
+      LOGICAL,INTENT(in)  :: shift
+      !
+      REAL(DP),OPTIONAL,INTENT(in) :: freq1(S%nat3)
+      COMPLEX(DP),OPTIONAL,INTENT(in) :: U1(S%nat3,S%nat3)
+      !
+      ! FUNCTION RESULT:
+      REAL(DP) :: spectralf(ne,S%nat3,nconf)
+      !
+      COMPLEX(DP) :: selfnrg(S%nat3,nconf)
+      !
+      INTEGER :: it, i, ie
+      REAL(DP) :: gamma(S%nat3,nconf), delta(S%nat3,nconf), omega, denom
+      COMPLEX(DP) :: U(S%nat3, S%nat3)
+      REAL(DP) :: freq(S%nat3)
+      !
+      ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q1
+      IF(present(freq1) .and. present(U1)) THEN
+         freq = freq1
+         U    = U1
+      ELSE
+         !CALL freq_phq_safe(xq(:,1), S, fc2, freq(:,1), U(:,:,1))
+         CALL freq_phq_safe(xq0, S, fc2, freq, U)
+      ENDIF
+      !
+      ! use lineshift to compute 3rd order linewidth and lineshift
+      IF(shift)THEN
+         selfnrg = selfnrg_q(xq0, nconf, T, sigma, S, grid, fc2, fc3)
+         gamma(:,:) = -DIMAG(selfnrg(:,:))
+         delta(:,:) =   DBLE(selfnrg(:,:))
+      ELSE
+         gamma = linewidth_q(xq0, S, fc2, fc3, grid, input)
+         delta = 0._dp
+      ENDIF
+      !
+      DO it = 1,nconf
+         WRITE(*,'(30x,6e12.2,5x,6e12.2)') gamma(:,it)*RY_TO_CMM1,delta(:,it)*RY_TO_CMM1
+      ENDDO
+      !
+      delta = 0._dp
+      ! Compute and superpose the Lorentzian functions corresponding to each band
+      DO it = 1,nconf
+         DO i = 1,S%nat3
+            DO ie = 1, ne
+               ! Only apply shift (i.e. real part of self nrg) if requested
+               omega = freq(i)
+               denom =   (ener(ie)**2 -omega**2 -2*omega*delta(i,it))**2 &
+                  + 4*omega**2 *gamma(i,it)**2
+               IF(ABS(denom)/=0._dp)THEN
+                  spectralf(ie,i,it) = 2*omega*gamma(i,it) / denom
+               ELSE
+                  spectralf(ie,i,it) = 0._dp
+               ENDIF
+            ENDDO
+         ENDDO
+      ENDDO
+      !
+   END FUNCTION simple_spectre_q
+
+
+   ! <<^V^\\=========================================//-//-//========//O\\//
+   ! Self energy for all the phonon bands at q in a range of frequencies
+   FUNCTION selfnrg_omega_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1) &
+      RESULT(selfnrg_wq)
+      USE q_grids,          ONLY : q_grid
+      USE input_fc,         ONLY : ph_system_info
+      USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
+      USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
+      !
+      IMPLICIT NONE
+      !
+      REAL(DP),INTENT(in) :: xq0(3)
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
+      !
+      INTEGER,INTENT(in)  :: ne
+      REAL(DP),INTENT(in) :: ener(ne)
+      !
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in)     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)           :: grid
+      REAL(DP),INTENT(in)               :: sigma(nconf) ! ry
+      !
+      REAL(DP),OPTIONAL,INTENT(in) :: freq1(S%nat3)
+      COMPLEX(DP),OPTIONAL,INTENT(in) :: U1(S%nat3,S%nat3)
+      !
+      ! To interpolate D2 and D3:
+      INTEGER :: iq, jq, it
+      COMPLEX(DP),ALLOCATABLE :: U(:,:,:), D3(:,:,:)
+      REAL(DP),ALLOCATABLE    :: V3sq(:,:,:)
+      REAL(DP) :: freq(S%nat3,3), bose(S%nat3,3), xq(3,3)
+      !
+      ! To compute the spectral function from the self energy:
+      INTEGER  :: nu0(3)
+      COMPLEX(DP),ALLOCATABLE :: selfnrg(:,:,:)
+      ! FUNCTION RESULT:
+      COMPLEX(DP) :: selfnrg_wq(ne,S%nat3,nconf)
+      !
+      ALLOCATE(U(S%nat3, S%nat3,3))
+      ALLOCATE(V3sq(S%nat3, S%nat3, S%nat3))
+      ALLOCATE(D3(S%nat3, S%nat3, S%nat3))
+      ALLOCATE(selfnrg(ne,S%nat3,nconf))
+      !
+      selfnrg = (0._dp, 0._dp)
+      !
+      ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q1
+      timer_CALL t_freq%start()
+      xq(:,1) = xq0
+      nu0(1) = set_nu0(xq(:,1), S%at)
+      IF(present(freq1) .and. present(U1)) THEN
+         freq(:,1) = freq1
+         U(:,:,1)    = U1
+      ELSE
+         CALL freq_phq_safe(xq(:,1), S, fc2, freq(:,1), U(:,:,1))
+      ENDIF
+      timer_CALL t_freq%stop()
+      !
+      DO iq = 1, grid%nq
+         !CALL print_percent_wall(33.333_dp, 300._dp, iq, grid%nq, (iq==1))
+         !
+         timer_CALL t_freq%start()
+         xq(:,2) = grid%xq(:,iq)
+         xq(:,3) = -(xq(:,2)+xq(:,1))
+!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
+         DO jq = 2,3
+            nu0(jq) = set_nu0(xq(:,jq), S%at)
+            CALL freq_phq_safe(xq(:,jq), S, fc2, freq(:,jq), U(:,:,jq))
+         ENDDO
+!$OMP END PARALLEL DO
+         timer_CALL t_freq%stop()
+         !
+         !
+         ! ------ start of CALL scatter_3q(S,fc2,fc3, xq(:,1),xq(:,2),xq(:,3), V3sq)
+         timer_CALL t_fc3int%start()
+         CALL fc3%interpolate(xq(:,2), xq(:,3), S%nat3, D3)
+         timer_CALL t_fc3int%stop()
+         timer_CALL t_fc3rot%start()
+         CALL ip_cart2pat(D3, S%nat3, U(:,:,1), U(:,:,2), U(:,:,3))
+         timer_CALL t_fc3rot%stop()
+         timer_CALL t_fc3m2%start()
+         V3sq = REAL( CONJG(D3)*D3 , kind=DP)
+         timer_CALL t_fc3m2%stop()
+         !
+         DO it = 1,nconf
+            ! Compute eigenvalues, eigenmodes and bose-einstein occupation at q2 and q3
+            timer_CALL t_bose%start()
+!$OMP PARALLEL DO DEFAULT(shared) PRIVATE(jq)
+            DO jq = 1,3
+               CALL bose_phq(T(it),s%nat3, freq(:,jq), bose(:,jq))
+            ENDDO
+!$OMP END PARALLEL DO
+            timer_CALL t_bose%stop()
+            timer_CALL t_sum%start()
+            selfnrg(:,:,it) = selfnrg(:,:,it) + grid%w(iq)*sum_selfnrg_spectre( S, sigma(it), freq, bose, V3sq, ne, ener, nu0 )
+            timer_CALL t_sum%stop()
+            !
+         ENDDO
+         !
+      ENDDO
+      !
+      timer_CALL t_mpicom%start()
+      IF(grid%scattered) CALL mpi_bsum(ne,S%nat3,nconf,selfnrg)
+      timer_CALL t_mpicom%stop()
+      selfnrg_wq = -0.5_dp * selfnrg
+      !
+      DEALLOCATE(U, V3sq, D3, selfnrg)
+      !
+   END FUNCTION selfnrg_omega_q
+   !
+   ! <<^V^\\=========================================//-//-//========//O\\//
+   ! Spectral weight function, computed as in eq. 1 of arXiv:1312.7467v1
+   FUNCTION spectre_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1, shift) &
+      RESULT(spectralf)
+      USE q_grids,          ONLY : q_grid
+      USE input_fc,         ONLY : ph_system_info
+      USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
+      USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
+      !
+      IMPLICIT NONE
+      !
+      REAL(DP),INTENT(in) :: xq0(3)
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
+      !
+      INTEGER,INTENT(in)  :: ne
+      REAL(DP),INTENT(in) :: ener(ne)
+      !
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in)     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: grid
+      REAL(DP),INTENT(in) :: sigma(nconf) ! ry
+      LOGICAL,INTENT(in)  :: shift ! set to false to drop the real part of the self-energy
+      !
+      REAL(DP),INTENT(in) :: freq1(S%nat3)
+      COMPLEX(DP),INTENT(in) :: U1(S%nat3,S%nat3)
+      !
+      ! To compute the spectral function from the self energy:
+      INTEGER  :: i, ie, it
+      REAL(DP) :: gamma, delta, omega, denom
+      COMPLEX(DP) :: selfnrg(ne,S%nat3,nconf)
+      ! FUNCTION RESULT:
+      REAL(DP)    :: spectralf(ne,S%nat3,nconf)
+      !
+      ! Once we have the self-energy, the rest is trivial
+      selfnrg = selfnrg_omega_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1)
+      !
+      timer_CALL t_mkspf%start()
+      DO it = 1,nconf
+         DO i = 1,S%nat3
+            DO ie = 1, ne
+               gamma =  -DIMAG(selfnrg(ie,i,it))
+               IF(shift) THEN
+                  delta =   DBLE(selfnrg(ie,i,it))
+               ELSE
+                  delta = 0._dp
+               ENDIF
+               omega = freq1(i)
+               denom =   (ener(ie)**2 -omega**2 -2*omega*delta)**2 &
+                  + 4*omega**2 *gamma**2
+               IF(ABS(denom)/=0._dp)THEN
+                  spectralf(ie,i,it) = 2*omega*gamma / denom
+               ELSE
+                  spectralf(ie,i,it) = 0._dp
+               ENDIF
+            ENDDO
+         ENDDO
+      ENDDO
+      timer_CALL t_mkspf%stop()
+      !
+   END FUNCTION spectre_q
+
+   ! <<^V^\\=========================================//-//-//========//O\\//
+   ! Spectral weight function, computed as in eq. 1 of arXiv:1312.7467v1
+   ! test, compute this as imaginary part of epsilon(omega)
+   FUNCTION spectre2_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1) &
+      RESULT(spectralf)
+      USE q_grids,          ONLY : q_grid
+      USE input_fc,         ONLY : ph_system_info
+      USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
+      USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
+      !
+      IMPLICIT NONE
+      !
+      REAL(DP),INTENT(in) :: xq0(3)
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
+      !
+      INTEGER,INTENT(in)  :: ne
+      REAL(DP),INTENT(in) :: ener(ne)
+      !
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in)     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: grid
+      REAL(DP),INTENT(in) :: sigma(nconf) ! ry
+      !LOGICAL,INTENT(in)  :: shift ! set to false to drop the real part of the self-energy
+      !
+      REAL(DP),INTENT(in) :: freq1(S%nat3)
+      COMPLEX(DP),INTENT(in) :: U1(S%nat3,S%nat3)
+      !
+      ! To compute the spectral function from the self energy:
+      INTEGER  :: i, ie, it
+      COMPLEX(DP) :: tepsilon(ne,S%nat3,nconf)
+      ! FUNCTION RESULT:
+      REAL(DP)    :: spectralf(ne,S%nat3,nconf)
+      !
+      ! Once we have the self-energy, the rest is trivial
+      tepsilon = tepsilon_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1)
+      !
+      timer_CALL t_mkspf%start()
+      DO it = 1,nconf
+         DO i = 1,S%nat3
+            DO ie = 1,ne
+               !IF(freq1(i)/=0._dp)THEN
+               spectralf(ie,i,it) = DIMAG(tepsilon(ie,i,it))
+               !ELSE
+               !  spectralf(ie,i,it) = 0._dp
+               !ENDIF
+            ENDDO
+         ENDDO
+      ENDDO
+      timer_CALL t_mkspf%stop()
+      !
+   END FUNCTION spectre2_q
+   !
+   ! <<^V^\\=========================================//-//-//========//O\\//
+   !  Complex \tilde{epsilon} in a range of frequencies
+   ! Experimental subroutine, assumes the material cubic and takes
+   ! epsilon(1,1) as epsilon_infty
+   FUNCTION tepsilon_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1) &
+      RESULT(tepsilon)
+      USE q_grids,          ONLY : q_grid
+      USE input_fc,         ONLY : ph_system_info
+      USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
+      USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
+      USE constants,        ONLY : fpi
+      !
+      IMPLICIT NONE
+      !
+      REAL(DP),INTENT(in) :: xq0(3)
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
+      !
+      INTEGER,INTENT(in)  :: ne
+      REAL(DP),INTENT(in) :: ener(ne)
+      !
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in)     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: grid
+      REAL(DP),INTENT(in) :: sigma(nconf) ! ry
+      !
+      REAL(DP),INTENT(in) :: freq1(S%nat3)
+      COMPLEX(DP),INTENT(in) :: U1(S%nat3,S%nat3)
+      !
+      ! To compute the spectral function from the self energy:
+      INTEGER  :: i, ie, it
+      REAL(DP) :: pref, epsilon_infty, rmass, zeu_i2
+      COMPLEX(DP) :: denom
+      COMPLEX(DP):: selfnrg(ne,S%nat3,nconf)
+      ! FUNCTION RESULT:
+      COMPLEX(DP)    :: tepsilon(ne,S%nat3,nconf)
+      !
+      EXTERNAL errore
+      IF(.not.S%lrigid) CALL errore("tepsilon","Cannot compute \tilde{epsilon} without epsilon0", 1)
+      ioWRITE(*,*) "BEWARE: tepsilon is only isotropic"
+      !
+      ! Once we have the self-energy, the rest is trivial
+      selfnrg = selfnrg_omega_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1)
+      !
+      ! S = 4piZ^2/(volume mass omega0^2)
+
+      rmass = S%amass(1)*S%amass(2)/(S%amass(1)+S%amass(2))
+      epsilon_infty = S%epsil(1,1)
+      zeu_i2        = S%zeu(1,1,1)**2
+      pref =  fpi * zeu_i2 /(S%omega * rmass)
+      !pref = 1/freq1(i)**2 ! 4 pi Z^2  / (Volume mu  omega0^2) # mu = reduced mass
+!     print*, "rmass", rmass, S%amass(1:2)
+!     print*, "epsilon", epsilon_infty
+!     print*, "zeu2", zeu_i2
+!     print*, "pref", pref
+!     print*, "vol", S%omega
+!     print*, "denom", rmass*S%omega
+!     print*, "fpi * zeu_i2", fpi * zeu_i2
+!  denom   1002568.9328649712
+!  epsilon   3.1410114605330000
+!  fpi * zeu_i2   48.024054760187823
+!  pref   4.7901000306236137E-005
+!  rmass   8793.6751743770546        22152.652305024902        14582.196429874200
+!  vol   114.01023041950073
+!  zeu2   3.8216328511998792
+!
+      timer_CALL t_mkspf%start()
+      tepsilon = DCMPLX(0._dp, 0._dp)
+      DO it = 1,nconf
+         DO i = 1,S%nat3
+            IF(freq1(i)==0._dp) CYCLE
+            DO ie = 1,ne
+               denom = freq1(i)**2 - ener(ie)**2 - 2*freq1(i)*selfnrg(ie,i,it)
+               IF(denom==DCMPLX(0._dp,0._dp)) CYCLE
+               !tepsilon(ie,i,it) = 1 + pref*freq1(i)**2/denom
+               tepsilon(ie,i,it) = epsilon_infty + pref/denom
+            ENDDO
+         ENDDO
+      ENDDO
+      timer_CALL t_mkspf%stop()
+      !
+   END FUNCTION tepsilon_q
+   !
+   ! <<^V^\\=========================================//-//-//========//O\\//
+   ! Infra red reflectivity |sqrt(epsilon)+1/sqrt(epsilon)-1|^2
+   ! Experimental! Assumes isoropic material and a bunch of other stuff
+   FUNCTION ir_reflectivity_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1) &
+      RESULT(reflectivity)
+      USE q_grids,          ONLY : q_grid
+      USE input_fc,         ONLY : ph_system_info
+      USE fc2_interpolate,  ONLY : forceconst2_grid, freq_phq_safe, bose_phq, set_nu0
+      USE fc3_interpolate,  ONLY : forceconst3, ip_cart2pat
+      !
+      IMPLICIT NONE
+      !
+      REAL(DP),INTENT(in) :: xq0(3)
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)     ! Kelvin
+      !
+      INTEGER,INTENT(in)  :: ne
+      REAL(DP),INTENT(in) :: ener(ne)
+      !
+      TYPE(forceconst2_grid),INTENT(in) :: fc2
+      CLASS(forceconst3),INTENT(in)     :: fc3
+      TYPE(ph_system_info),INTENT(in)   :: S
+      TYPE(q_grid),INTENT(in)      :: grid
+      REAL(DP),INTENT(in) :: sigma(nconf) ! ry
+      !
+      REAL(DP),INTENT(in) :: freq1(S%nat3)
+      COMPLEX(DP),INTENT(in) :: U1(S%nat3,S%nat3)
+      !
+      ! To compute the spectral function from the self energy:
+      INTEGER  :: i, it
+      COMPLEX(DP) :: tepsilon(ne,S%nat3,nconf)
+      COMPLEX(DP) :: aux(ne),aux2(ne)
+      ! FUNCTION RESULT:
+      REAL(DP)    :: reflectivity(ne,S%nat3,nconf)
+      !
+      ! We use tilde{epsilon}, which itself comes from the self-energy
+      tepsilon = tepsilon_q(xq0, nconf, T, sigma, S, grid, fc2, fc3, ne, ener, freq1, U1)
+      !
+      timer_CALL t_mkspf%start()
+      DO it = 1,nconf
+         DO i = 1,S%nat3
+            aux  = SQRT(tepsilon(:,i,it))
+            aux2 = (aux-1)/(aux+1)
+            reflectivity(:,i,it) = DBLE(aux2*CONJG(aux2))
+         ENDDO
+      ENDDO
+      timer_CALL t_mkspf%stop()
+      !
+   END FUNCTION ir_reflectivity_q
+   !
+   ! Sum the self energy at the provided ener(ne) input energies
+   ! \/o\________\\\_________________________________________/^>
+   FUNCTION sum_selfnrg_spectre(S, sigma, freq, bose, V3sq, ne, ener, nu0)
+      USE input_fc,           ONLY : ph_system_info
+      USE merge_degenerate,   ONLY : merge_degen
+      USE functions,          ONLY : sigma_mgo
+      IMPLICIT NONE
+      TYPE(ph_system_info),INTENT(in)   :: S
+      REAL(DP),INTENT(in) :: sigma   ! smearing (regularization) (Ry)
+      REAL(DP),INTENT(in) :: freq(S%nat3,3)  ! phonon energies (Ry)
+      REAL(DP),INTENT(in) :: bose(S%nat3,3)  ! bose/einstein distribution of freq
+      REAL(DP),INTENT(in) :: V3sq(S%nat3,S%nat3,S%nat3) ! |D^3|**2 on the basis of phonons patterns
+      !
+      INTEGER,INTENT(in)  :: ne           ! number of energies...
+      REAL(DP),INTENT(in) :: ener(ne)     ! energies for which to compute the spectral function
+      INTEGER,INTENT(in)  :: nu0(3)       ! first non-zero phomnon frequency
+      !
+      ! _P -> scattering, _M -> cohalescence
+      REAL(DP) :: bose_P, bose_M      ! final/initial state populations
+      REAL(DP) :: factor, sigma_, T=0._dp !freqtotm1
+      REAL(DP) :: omega_P,  omega_M   ! \delta\omega
+      REAL(DP) :: omega_P2, omega_M2  ! \delta\omega
+      COMPLEX(DP) :: ctm_P,ctm_M, reg
+      COMPLEX(DP) :: ctm(ne)
+      REAL(DP)    :: freqm1(S%nat3,3)  ! phonon energies (Ry)
+      !
+      INTEGER :: i,j,k, ie
+      !
+      ! Note: using the function result in an OMP reduction causes crash with ifort 14
+      COMPLEX(DP) :: sum_selfnrg_spectre(ne,S%nat3)
+      COMPLEX(DP),ALLOCATABLE :: spf(:,:)
+      !
+!     IF(sigma<=0._dp)THEN
+!       CALL errore("sum_selfnrg_spectre","spf not implemented in the static limit. "&
+!                   //"NEW: To do unshifted spf use 'spf imag'",1)
+!     ENDIF
+      !
+      ALLOCATE(spf(ne,S%nat3))
+      spf = (0._dp, 0._dp)
+      !
+      DO i = 1,S%nat3
+         IF(i>=nu0(1)) freqm1(i,1) = 0.5_dp/freq(i,1)
+         IF(i>=nu0(2)) freqm1(i,2) = 0.5_dp/freq(i,2)
+         IF(i>=nu0(3)) freqm1(i,3) = 0.5_dp/freq(i,3)
+      ENDDO
+      !
 !$OMP PARALLEL DO DEFAULT(SHARED) &
 !$OMP             PRIVATE(ie,i,j,k,bose_P,bose_M,omega_P,omega_M,omega_P2,omega_M2, &
 !$OMP                     ctm_P,ctm_M,ctm,reg,factor) &
 !$OMP             REDUCTION(+: spf) COLLAPSE(2)
-    DO k = 1,S%nat3
-      DO j = 1,S%nat3
-        !
-        bose_P   = 1 + bose(j,2) + bose(k,3)
-        omega_P  = freq(j,2)+freq(k,3)
-        omega_P2 = omega_P**2
-        !
-        bose_M   = bose(k,3) - bose(j,2)
-        omega_M  = freq(j,2)-freq(k,3)
-        omega_M2 = omega_M**2
-        !
-        ! A little optimization: precompute the parts that depends only on the energy
+      DO k = 1,S%nat3
+         DO j = 1,S%nat3
+            !
+            bose_P   = 1 + bose(j,2) + bose(k,3)
+            omega_P  = freq(j,2)+freq(k,3)
+            omega_P2 = omega_P**2
+            !
+            bose_M   = bose(k,3) - bose(j,2)
+            omega_M  = freq(j,2)-freq(k,3)
+            omega_M2 = omega_M**2
+            !
+            ! A little optimization: precompute the parts that depends only on the energy
 ! ! !         DO ie = 1,ne
 ! ! !           ! regularization:
 ! ! !           reg = CMPLX(ener(ie), sigma, kind=DP)**2
@@ -759,155 +1134,155 @@ MODULE linewidth
 ! ! !           ctm_M = 2 * bose_M *omega_M/(omega_M2-reg)
 ! ! !           ctm(ie) = ctm_P + ctm_M
 ! ! !         ENDDO
-        !
-        DO i = 1,S%nat3
-          !
-          factor = V3sq(i,j,k) *freqm1(i,1)*freqm1(j,2)*freqm1(k,3)
-          !
-          IF(ABS(sigma-666._dp)< 1._dp)THEN
-          sigma_ = sigma_mgo(freq(i,1),T) &
-                  +sigma_mgo(freq(j,2),T) &
-                  +sigma_mgo(freq(k,3),T)
-          !print*, RY_TO_CMM1*freq(i,1), RY_TO_CMM1*freq(j,2), RY_TO_CMM1*freq(k,3), RY_TO_CMM1*sigma_
-          ELSE
-           sigma_ = sigma
-          ENDIF
+            !
+            DO i = 1,S%nat3
+               !
+               factor = V3sq(i,j,k) *freqm1(i,1)*freqm1(j,2)*freqm1(k,3)
+               !
+               IF(ABS(sigma-666._dp)< 1._dp)THEN
+                  sigma_ = sigma_mgo(freq(i,1),T) &
+                     +sigma_mgo(freq(j,2),T) &
+                     +sigma_mgo(freq(k,3),T)
+                  !print*, RY_TO_CMM1*freq(i,1), RY_TO_CMM1*freq(j,2), RY_TO_CMM1*freq(k,3), RY_TO_CMM1*sigma_
+               ELSE
+                  sigma_ = sigma
+               ENDIF
 
-          DO ie = 1, ne
-            ! regularization:
-            reg = CMPLX(ener(ie), sigma_, kind=DP)**2
-            !
-            ctm_P = 2 * bose_P *omega_P/(omega_P2-reg)
-            ctm_M = 2 * bose_M *omega_M/(omega_M2-reg)
-            ctm(ie) = ctm_P + ctm_M
-            !
-            spf(ie,i) = spf(ie,i) + ctm(ie) * factor !V3sq(i,j,k) * freqtotm1
-          ENDDO
+               DO ie = 1, ne
+                  ! regularization:
+                  reg = CMPLX(ener(ie), sigma_, kind=DP)**2
+                  !
+                  ctm_P = 2 * bose_P *omega_P/(omega_P2-reg)
+                  ctm_M = 2 * bose_M *omega_M/(omega_M2-reg)
+                  ctm(ie) = ctm_P + ctm_M
+                  !
+                  spf(ie,i) = spf(ie,i) + ctm(ie) * factor !V3sq(i,j,k) * freqtotm1
+               ENDDO
 ! ! !           spf(:,i) = spf(:,i) + ctm(:) * factor !V3sq(i,j,k) * freqtotm1
-            
-          !
-        ENDDO
+
+               !
+            ENDDO
+         ENDDO
       ENDDO
-    ENDDO
 !$OMP END PARALLEL DO
-    !
-    CALL merge_degen(ne, S%nat3, spf, freq(:,1))
-    sum_selfnrg_spectre = spf
-    DEALLOCATE(spf)
-    !
-  END FUNCTION sum_selfnrg_spectre
-  !
-  ! \/o\________\\\_________________________________________/^>
-  ! Sum the self energy in a range of frequencies
-  FUNCTION sum_selfnrg_modes(S, sigma, T, freq, bose, V3sq, nu0)
-    USE input_fc,           ONLY : ph_system_info
-    USE functions,          ONLY : df_bose
-    USE merge_degenerate,   ONLY : merge_degen
-    USE functions,          ONLY : sigma_mgo
-    IMPLICIT NONE
-    TYPE(ph_system_info),INTENT(in)   :: S
-    REAL(DP),INTENT(in) :: sigma, T
-    REAL(DP),INTENT(in) :: freq(S%nat3,3)
-    REAL(DP),INTENT(in) :: bose(S%nat3,3)
-    REAL(DP),INTENT(in) :: V3sq(S%nat3,S%nat3,S%nat3)
-    INTEGER,INTENT(in)  :: nu0(3)
-    !
-    ! _P -> scattering, _M -> cohalescence
-    REAL(DP) :: bose_P, bose_M      ! final/initial state populations 
-    REAL(DP) :: freqtotm1
-    REAL(DP) :: omega_P,  omega_M   ! \sigma\omega
-    REAL(DP) :: omega_P2, omega_M2  ! \sigma\omega
-    COMPLEX(DP) :: ctm_P, ctm_M, reg
-    REAL(DP) :: freqm1(S%nat3,3), sigma_
-    !
-    INTEGER :: i,j,k
-    ! Note: using the function result in an OMP reduction causes crash with ifort 14
-    COMPLEX(DP) :: sum_selfnrg_modes(S%nat3)
-    COMPLEX(DP) :: se(S%nat3)
-    !
-    se(:) = (0._dp, 0._dp)
-    !
-     freqm1 = 0._dp
-     DO i = 1,S%nat3
-       IF(i>=nu0(1)) freqm1(i,1) = 0.5_dp/freq(i,1)
-       IF(i>=nu0(2)) freqm1(i,2) = 0.5_dp/freq(i,2)
-       IF(i>=nu0(3)) freqm1(i,3) = 0.5_dp/freq(i,3)
-     ENDDO
-    !
+      !
+      CALL merge_degen(ne, S%nat3, spf, freq(:,1))
+      sum_selfnrg_spectre = spf
+      DEALLOCATE(spf)
+      !
+   END FUNCTION sum_selfnrg_spectre
+   !
+   ! \/o\________\\\_________________________________________/^>
+   ! Sum the self energy in a range of frequencies
+   FUNCTION sum_selfnrg_modes(S, sigma, T, freq, bose, V3sq, nu0)
+      USE input_fc,           ONLY : ph_system_info
+      USE functions,          ONLY : df_bose
+      USE merge_degenerate,   ONLY : merge_degen
+      USE functions,          ONLY : sigma_mgo
+      IMPLICIT NONE
+      TYPE(ph_system_info),INTENT(in)   :: S
+      REAL(DP),INTENT(in) :: sigma, T
+      REAL(DP),INTENT(in) :: freq(S%nat3,3)
+      REAL(DP),INTENT(in) :: bose(S%nat3,3)
+      REAL(DP),INTENT(in) :: V3sq(S%nat3,S%nat3,S%nat3)
+      INTEGER,INTENT(in)  :: nu0(3)
+      !
+      ! _P -> scattering, _M -> cohalescence
+      REAL(DP) :: bose_P, bose_M      ! final/initial state populations
+      REAL(DP) :: freqtotm1
+      REAL(DP) :: omega_P,  omega_M   ! \sigma\omega
+      REAL(DP) :: omega_P2, omega_M2  ! \sigma\omega
+      COMPLEX(DP) :: ctm_P, ctm_M, reg
+      REAL(DP) :: freqm1(S%nat3,3), sigma_
+      !
+      INTEGER :: i,j,k
+      ! Note: using the function result in an OMP reduction causes crash with ifort 14
+      COMPLEX(DP) :: sum_selfnrg_modes(S%nat3)
+      COMPLEX(DP) :: se(S%nat3)
+      !
+      se(:) = (0._dp, 0._dp)
+      !
+      freqm1 = 0._dp
+      DO i = 1,S%nat3
+         IF(i>=nu0(1)) freqm1(i,1) = 0.5_dp/freq(i,1)
+         IF(i>=nu0(2)) freqm1(i,2) = 0.5_dp/freq(i,2)
+         IF(i>=nu0(3)) freqm1(i,3) = 0.5_dp/freq(i,3)
+      ENDDO
+      !
 !$OMP PARALLEL DO DEFAULT(SHARED) &
 !$OMP             PRIVATE(i,j,k,bose_P,bose_M,omega_P,omega_M,&
 !$OMP                     omega_P2,omega_M2,ctm_P,ctm_M,reg,freqtotm1) &
 !$OMP             REDUCTION(+: se) COLLAPSE(2)
-    DO k = 1,S%nat3
-      DO j = 1,S%nat3
-        !
-        bose_P   = 1 + bose(j,2) + bose(k,3)
-        bose_M   = bose(k,3) - bose(j,2)
-        omega_P  = freq(j,2)+freq(k,3)
-        omega_M  = freq(j,2)-freq(k,3)
-        !
-        IF(sigma>0._dp)THEN
-          omega_P2 = omega_P**2
-          omega_M2 = omega_M**2
-        ELSE IF(sigma<0._dp)THEN ! (static limit)
-          ctm_P = 2 * bose_P *omega_P/(omega_P**2+sigma**2)
-          ctm_M = 2 * bose_M *omega_M/(omega_M**2+sigma**2)
-        ELSE !IF (sigma==0._dp)THEN
-          ! In the static limit with sigma=0 case we have to take the 
-          ! derivative of (n_3-n2)/(w_2-w_3) when w_2 is close to w_3
-          IF(omega_P>0._dp)THEN
-            ctm_P = 2 * bose_P /omega_P
-          ELSE
-            ctm_P = 0._dp
-          ENDIF
-          !
-          IF(ABS(omega_M)>1.e-5_dp)THEN
-            ctm_M = 2 * bose_M /omega_M
-          ELSE
-            IF(T>0._dp)THEN
-              ctm_M = -2* df_bose(0.5_dp * omega_P, T)
-            ELSE
-              ctm_M = 0._dp
+      DO k = 1,S%nat3
+         DO j = 1,S%nat3
+            !
+            bose_P   = 1 + bose(j,2) + bose(k,3)
+            bose_M   = bose(k,3) - bose(j,2)
+            omega_P  = freq(j,2)+freq(k,3)
+            omega_M  = freq(j,2)-freq(k,3)
+            !
+            IF(sigma>0._dp)THEN
+               omega_P2 = omega_P**2
+               omega_M2 = omega_M**2
+            ELSE IF(sigma<0._dp)THEN ! (static limit)
+               ctm_P = 2 * bose_P *omega_P/(omega_P**2+sigma**2)
+               ctm_M = 2 * bose_M *omega_M/(omega_M**2+sigma**2)
+            ELSE !IF (sigma==0._dp)THEN
+               ! In the static limit with sigma=0 case we have to take the
+               ! derivative of (n_3-n2)/(w_2-w_3) when w_2 is close to w_3
+               IF(omega_P>0._dp)THEN
+                  ctm_P = 2 * bose_P /omega_P
+               ELSE
+                  ctm_P = 0._dp
+               ENDIF
+               !
+               IF(ABS(omega_M)>1.e-5_dp)THEN
+                  ctm_M = 2 * bose_M /omega_M
+               ELSE
+                  IF(T>0._dp)THEN
+                     ctm_M = -2* df_bose(0.5_dp * omega_P, T)
+                  ELSE
+                     ctm_M = 0._dp
+                  ENDIF
+               ENDIF
+               !
             ENDIF
-          ENDIF
-          !
-        ENDIF
-        !
-        DO i = 1,S%nat3
-          !
-          !IF(freq(i,1)<1.d-3 .or. freq(j,2)<1.d-3 .or. freq(k,3)<1.d-3) CYCLE
-          ! This comes from the definition of u_qj, Ref. 1. (there is an hidden factor 1/8)
-          freqtotm1 = freqm1(i,1)*freqm1(j,2)*freqm1(k,3)
-          !
-          ! regularization:
-          IF(sigma>0._dp)THEN
-            IF(ABS(sigma-666._dp)<1._dp)THEN
-            sigma_ = sigma_mgo(freq(i,1),T) &
-                    +sigma_mgo(freq(j,2),T) &
-                    +sigma_mgo(freq(k,3),T)
-            !print*, RY_TO_CMM1*freq(i,1), RY_TO_CMM1*freq(j,2), RY_TO_CMM1*freq(k,3), RY_TO_CMM1*sigma_
-            ELSE
-             sigma_ = sigma
-            ENDIF
-          
-            reg = CMPLX(freq(i,1), sigma_, kind=DP)**2
-            ctm_P = 2 * bose_P *omega_P/(omega_P2-reg )
-            ctm_M = 2 * bose_M *omega_M/(omega_M2-reg )
-          ENDIF
-          !
-          !
-          se(i) = se(i) + (ctm_P + ctm_M)*freqtotm1 * V3sq(i,j,k)
-          !
-        ENDDO
+            !
+            DO i = 1,S%nat3
+               !
+               !IF(freq(i,1)<1.d-3 .or. freq(j,2)<1.d-3 .or. freq(k,3)<1.d-3) CYCLE
+               ! This comes from the definition of u_qj, Ref. 1. (there is an hidden factor 1/8)
+               freqtotm1 = freqm1(i,1)*freqm1(j,2)*freqm1(k,3)
+               !
+               ! regularization:
+               IF(sigma>0._dp)THEN
+                  IF(ABS(sigma-666._dp)<1._dp)THEN
+                     sigma_ = sigma_mgo(freq(i,1),T) &
+                        +sigma_mgo(freq(j,2),T) &
+                        +sigma_mgo(freq(k,3),T)
+                     !print*, RY_TO_CMM1*freq(i,1), RY_TO_CMM1*freq(j,2), RY_TO_CMM1*freq(k,3), RY_TO_CMM1*sigma_
+                  ELSE
+                     sigma_ = sigma
+                  ENDIF
+
+                  reg = CMPLX(freq(i,1), sigma_, kind=DP)**2
+                  ctm_P = 2 * bose_P *omega_P/(omega_P2-reg )
+                  ctm_M = 2 * bose_M *omega_M/(omega_M2-reg )
+               ENDIF
+               !
+               !
+               se(i) = se(i) + (ctm_P + ctm_M)*freqtotm1 * V3sq(i,j,k)
+               !
+            ENDDO
+         ENDDO
       ENDDO
-    ENDDO
 !$OMP END PARALLEL DO
-    !
-    CALL merge_degen(S%nat3, se, freq(:,1))
-    sum_selfnrg_modes = se
-    !
-  END FUNCTION sum_selfnrg_modes
-  !
+      !
+      CALL merge_degen(S%nat3, se, freq(:,1))
+      sum_selfnrg_modes = se
+      !
+   END FUNCTION sum_selfnrg_modes
+   !
   ! Sum the Imaginary part of the self energy for the phonon modes, uses gaussian function for energy delta
   ! \/o\________\\\_________________________________________/^>
   FUNCTION sum_linewidth_modes(S, sigma, freq, bose, V3sq, nu0)
@@ -982,62 +1357,64 @@ MODULE linewidth
     !
   END FUNCTION sum_linewidth_modes
 
-  ! \/o\________\\\_________________________________________/^>
-  ! Add the elastic peak of Raman
-  SUBROUTINE add_exp_t_factor(nconf, T, ne, nat3, ener, spectralf)
-    USE functions,      ONLY : f_bose
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)
-    INTEGER,INTENT(in)  :: ne, nat3
-    REAL(DP),INTENT(in) :: ener(ne)
-    !
-    REAL(DP),INTENT(inout) :: spectralf(ne,nat3,nconf)
-    !
-    REAL(DP) :: factor(ne)
-    INTEGER :: it,ie,nu
-    !
-    DO it = 1,nconf
-      factor = (1 + f_bose(ener,T(it))) / ener
+   ! \/o\________\\\_________________________________________/^>
+   ! Add the elastic peak of Raman
+   SUBROUTINE add_exp_t_factor(nconf, T, ne, nat3, ener, spectralf)
+      USE functions,      ONLY : f_bose
+      IMPLICIT NONE
       !
-      DO nu = 1,nat3
-        DO ie = 1,ne
-          spectralf(ie,nu,it) = factor(ie)*spectralf(ie,nu,it)
-        ENDDO
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)
+      INTEGER,INTENT(in)  :: ne, nat3
+      REAL(DP),INTENT(in) :: ener(ne)
+      !
+      REAL(DP),INTENT(inout) :: spectralf(ne,nat3,nconf)
+      !
+      REAL(DP) :: factor(ne)
+      INTEGER :: it,ie,nu
+      !
+      DO it = 1,nconf
+         factor = (1 + f_bose(ener,T(it))) / ener
+         !
+         DO nu = 1,nat3
+            DO ie = 1,ne
+               spectralf(ie,nu,it) = factor(ie)*spectralf(ie,nu,it)
+            ENDDO
+         ENDDO
+         !
       ENDDO
       !
-    ENDDO
-    !
-  END SUBROUTINE add_exp_t_factor
-  !
-  ! \/o\________\\\_________________________________________/^>
-  SUBROUTINE gauss_convolution(nconf, T, ne, nat3, ener, spectralf)
-    USE functions,      ONLY : f_bose
-    IMPLICIT NONE
-    !
-    INTEGER,INTENT(in)  :: nconf
-    REAL(DP),INTENT(in) :: T(nconf)
-    INTEGER,INTENT(in)  :: ne, nat3
-    REAL(DP),INTENT(in) :: ener(ne)
-    !
-    REAL(DP),INTENT(inout) :: spectralf(ne,nat3,nconf)
-    !
-    REAL(DP) :: convol(ne)
-    !
-    INTEGER :: it,ie,je,nu
-    !
-    convol = f_bose(ener,T(it))
+   END SUBROUTINE add_exp_t_factor
+   !
+   ! \/o\________\\\_________________________________________/^>
+   SUBROUTINE gauss_convolution(nconf, T, ne, nat3, ener, spectralf)
+      USE functions,      ONLY : f_bose
+      IMPLICIT NONE
+      !
+      INTEGER,INTENT(in)  :: nconf
+      REAL(DP),INTENT(in) :: T(nconf)
+      INTEGER,INTENT(in)  :: ne, nat3
+      REAL(DP),INTENT(in) :: ener(ne)
+      !
+      REAL(DP),INTENT(inout) :: spectralf(ne,nat3,nconf)
+      !
+      REAL(DP) :: convol(ne)
+      !
+      INTEGER :: it,ie,nu
+      !
+      convol = f_bose(ener,T(it))
 
-    DO it = 1,nconf
-    DO nu = 1,nat3
-      DO ie = 1,ne
-        spectralf(ie,nu,it) = convol(ie)*spectralf(ie,nu,it)
+      DO it = 1,nconf
+         DO nu = 1,nat3
+            DO ie = 1,ne
+               spectralf(ie,nu,it) = convol(ie)*spectralf(ie,nu,it)
+            ENDDO
+         ENDDO
       ENDDO
-    ENDDO
-    ENDDO
-    !
-  END SUBROUTINE gauss_convolution
-  !
-  !
+      !
+   END SUBROUTINE gauss_convolution
+   !
+   !
 END MODULE linewidth
+
+

--- a/thermal2/make.depend
+++ b/thermal2/make.depend
@@ -53,6 +53,7 @@ q_grids.o : mpi_thermal.o
 quter.o : mpi_thermal.o
 read_md.o : mpi_thermal.o
 rigid_d3.o : mpi_thermal.o
+thtetra.o : mpi_thermal.o
 timers.o : mpi_thermal.o
 variational_tk.o : mpi_thermal.o
 variational_tk_symq.o : mpi_thermal.o
@@ -268,6 +269,7 @@ fc2_interp.o : ./rigid_d3.o
 fc2_interp.o : ./timers.o
 fc3_interp.o : ./input_fc.o
 fc3_interp.o : ./mpi_thermal.o
+fc3_interp.o : ./ph_system.o
 final_state.o : ./fc2_interp.o
 final_state.o : ./fc3_interp.o
 final_state.o : ./functions.o
@@ -293,6 +295,7 @@ isotopes.o : ./mpi_thermal.o
 isotopes.o : ./nanoclock.o
 isotopes.o : ./nist_isotopes_db.o
 isotopes.o : ./q_grids.o
+linewidth.o : ./code_input.o
 linewidth.o : ./fc2_interp.o
 linewidth.o : ./fc3_interp.o
 linewidth.o : ./functions.o
@@ -300,6 +303,7 @@ linewidth.o : ./input_fc.o
 linewidth.o : ./merge_degenerate.o
 linewidth.o : ./mpi_thermal.o
 linewidth.o : ./q_grids.o
+linewidth.o : ./thtetra.o
 linewidth.o : ./timers.o
 mc_grids.o : ./code_input.o
 mc_grids.o : ./fc2_interp.o
@@ -337,15 +341,18 @@ ph_velocity.o : ./more_constants.o
 posix_signal.o : ./mpi_thermal.o
 posix_signal.o : ./timers.o
 q_grids.o : ./fc2_interp.o
+q_grids.o : ./fc3_interp.o
 q_grids.o : ./functions.o
 q_grids.o : ./input_fc.o
 q_grids.o : ./lebedev.o
 q_grids.o : ./mpi_thermal.o
+q_grids.o : ./ph_system.o
 q_grids.o : ./ph_velocity.o
 quter.o : ./functions.o
 quter.o : ./input_fc.o
 read_md.o : ./input_fc.o
 read_md.o : ./mpi_thermal.o
+thtetra.o : ./mpi_thermal.o
 timers.o : ./mpi_thermal.o
 timers.o : ./nanoclock.o
 variational_tk.o : ./casimir.o

--- a/thermal2/mpi_thermal.f90
+++ b/thermal2/mpi_thermal.f90
@@ -8,8 +8,8 @@
 ! hack:
 #if defined(__XLF)
 SUBROUTINE FLUSH(un)
- INTEGER :: un
- RETURN
+  INTEGER :: un
+  RETURN
 END SUBROUTINE
 #endif
 
@@ -23,19 +23,19 @@ MODULE mpi_thermal
 #define __MPI_THERMAL
 #include "mpi_thermal.h"
 
-!dir$ message "----------------------------------------------------------------------------------------------" 
+!dir$ message "----------------------------------------------------------------------------------------------"
 #ifdef __MPI
-!dir$ message "Compiling _with_ MPI support" 
+!dir$ message "Compiling _with_ MPI support"
 #else
-!dir$ message "Compiling _without_ MPI support (mpi subroutines will do nothing)" 
+!dir$ message "Compiling _without_ MPI support (mpi subroutines will do nothing)"
 #endif
 !
 #ifdef _OPENMP
-!dir$ message "Compiling _with_ OpenMP directives" 
+!dir$ message "Compiling _with_ OpenMP directives"
 #else
-!dir$ message "Compiling _without_ OpenMP directives" 
+!dir$ message "Compiling _without_ OpenMP directives"
 #endif
-!dir$ message "----------------------------------------------------------------------------------------------" 
+!dir$ message "----------------------------------------------------------------------------------------------"
 
   INTEGER :: my_id=0, num_procs=1, ierr
   LOGICAL :: ionode = .TRUE. ! everyone is ionode before I start MPI
@@ -43,46 +43,46 @@ MODULE mpi_thermal
   INTEGER :: omp_tot_thr=1
 
   INTERFACE mpi_broadcast
-     MODULE PROCEDURE mpi_bcast_logical
-     !
-     MODULE PROCEDURE mpi_bcast_scl
-     MODULE PROCEDURE mpi_bcast_vec
-     MODULE PROCEDURE mpi_bcast_mat
-     MODULE PROCEDURE mpi_bcast_tns
-     MODULE PROCEDURE mpi_bcast_tns4
-     !
-     MODULE PROCEDURE mpi_bcast_zscl
-     MODULE PROCEDURE mpi_bcast_zvec
-     MODULE PROCEDURE mpi_bcast_zmat
-     MODULE PROCEDURE mpi_bcast_ztns
-     MODULE PROCEDURE mpi_bcast_ztns4
-     !
-     MODULE PROCEDURE mpi_bcast_integer
-     MODULE PROCEDURE mpi_bcast_integer_vec
-     MODULE PROCEDURE mpi_bcast_integer_mat
-     !
-     MODULE PROCEDURE mpi_bcast_character
+    MODULE PROCEDURE mpi_bcast_logical
+    !
+    MODULE PROCEDURE mpi_bcast_scl
+    MODULE PROCEDURE mpi_bcast_vec
+    MODULE PROCEDURE mpi_bcast_mat
+    MODULE PROCEDURE mpi_bcast_tns
+    MODULE PROCEDURE mpi_bcast_tns4
+    !
+    MODULE PROCEDURE mpi_bcast_zscl
+    MODULE PROCEDURE mpi_bcast_zvec
+    MODULE PROCEDURE mpi_bcast_zmat
+    MODULE PROCEDURE mpi_bcast_ztns
+    MODULE PROCEDURE mpi_bcast_ztns4
+    !
+    MODULE PROCEDURE mpi_bcast_integer
+    MODULE PROCEDURE mpi_bcast_integer_vec
+    MODULE PROCEDURE mpi_bcast_integer_mat
+    !
+    MODULE PROCEDURE mpi_bcast_character
   END INTERFACE
   !
   INTERFACE mpi_bsum
-     MODULE PROCEDURE mpi_bsum_int
-     MODULE PROCEDURE mpi_bsum_ivec
+    MODULE PROCEDURE mpi_bsum_int
+    MODULE PROCEDURE mpi_bsum_ivec
 
-     MODULE PROCEDURE mpi_bsum_scl
-     MODULE PROCEDURE mpi_bsum_vec
-     MODULE PROCEDURE mpi_bsum_mat
-     MODULE PROCEDURE mpi_bsum_tns
-     MODULE PROCEDURE mpi_bsum_tns4
+    MODULE PROCEDURE mpi_bsum_scl
+    MODULE PROCEDURE mpi_bsum_vec
+    MODULE PROCEDURE mpi_bsum_mat
+    MODULE PROCEDURE mpi_bsum_tns
+    MODULE PROCEDURE mpi_bsum_tns4
 
-     MODULE PROCEDURE mpi_bsum_zscl
-     MODULE PROCEDURE mpi_bsum_zvec
-     MODULE PROCEDURE mpi_bsum_zmat
-     MODULE PROCEDURE mpi_bsum_ztns
-     MODULE PROCEDURE mpi_bsum_ztns4
+    MODULE PROCEDURE mpi_bsum_zscl
+    MODULE PROCEDURE mpi_bsum_zvec
+    MODULE PROCEDURE mpi_bsum_zmat
+    MODULE PROCEDURE mpi_bsum_ztns
+    MODULE PROCEDURE mpi_bsum_ztns4
   END INTERFACE
 
 
-  CONTAINS
+CONTAINS
 
   SUBROUTINE start_mpi()
     IMPLICIT NONE
@@ -105,7 +105,7 @@ MODULE mpi_thermal
 #ifdef _OPENMP
     omp_tot_thr =  omp_get_max_threads()
 #else
-   omp_tot_thr = 1
+    omp_tot_thr = 1
 #endif
     CALL mpi_bsum(omp_tot_thr)
     IF(ionode .and. omp_tot_thr>num_procs) WRITE(*,"(2x,a,i6,a)") &
@@ -115,34 +115,34 @@ MODULE mpi_thermal
 
   SUBROUTINE stop_mpi()
 #ifdef __MPI
-     call MPI_FINALIZE ( ierr )
+    call MPI_FINALIZE ( ierr )
 #endif
   END SUBROUTINE
 
   SUBROUTINE abort_mpi(errorcode)
-        IMPLICIT NONE
-        INTEGER :: ierr
-        INTEGER, INTENT(IN):: errorcode
+    IMPLICIT NONE
+    INTEGER :: ierr
+    INTEGER, INTENT(IN):: errorcode
 #ifdef __MPI
-        CALL mpi_abort(mpi_comm_world, errorcode, ierr)
+    CALL mpi_abort(mpi_comm_world, errorcode, ierr)
 #endif
   END SUBROUTINE
 
   SUBROUTINE mpi_wbarrier()
-        IMPLICIT NONE
-        INTEGER :: ierr
+    IMPLICIT NONE
+    INTEGER :: ierr
 #ifdef __MPI
-        CALL mpi_barrier(mpi_comm_world, ierr)
+    CALL mpi_barrier(mpi_comm_world, ierr)
 #endif
   END SUBROUTINE
-  
+
   SUBROUTINE mpi_any(lgc)
     IMPLICIT NONE
     LOGICAL,INTENT(inout) :: lgc
 
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, lgc, 1, MPI_LOGICAL, MPI_LOR,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -152,17 +152,17 @@ MODULE mpi_thermal
 
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, lgc, 1, MPI_LOGICAL, MPI_LAND,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
-   END SUBROUTINE
- 
+  END SUBROUTINE
+
   ! In-place MPI sum of integer, scalar, vector and matrix
   SUBROUTINE mpi_bsum_int(scl)
     IMPLICIT NONE
     INTEGER,INTENT(inout) :: scl
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, scl, 1, MPI_INTEGER, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -172,7 +172,7 @@ MODULE mpi_thermal
     INTEGER,INTENT(inout) :: vec(nn)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, vec, nn, MPI_INTEGER, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -200,7 +200,7 @@ MODULE mpi_thermal
     REAL(DP),INTENT(inout) :: scl
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, scl, 1, MPI_DOUBLE_PRECISION, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -210,7 +210,7 @@ MODULE mpi_thermal
     REAL(DP),INTENT(inout) :: vec(nn)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, vec, nn, MPI_DOUBLE_PRECISION, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -220,7 +220,27 @@ MODULE mpi_thermal
     REAL(DP),INTENT(inout) :: mat(mm,nn)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, mat, mm*nn, MPI_DOUBLE_PRECISION, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
+#endif
+  END SUBROUTINE
+  !
+  SUBROUTINE mpi_sum_mat(mm, nn, mat)
+    IMPLICIT NONE
+    INTEGER,INTENT(in)     :: mm, nn
+    COMPLEX(DP),INTENT(inout) :: mat(mm,nn)
+    INTEGER :: rank_id
+    INTEGER :: info
+
+#ifdef __MPI
+    CALL mpi_comm_rank( MPI_COMM_WORLD, rank_id, info )
+    IF( info /= 0 ) CALL errore( 'reduce_base_real', 'error in mpi_comm_rank', info )
+    IF (rank_id == 0) THEN
+      CALL MPI_REDUCE( MPI_IN_PLACE, mat, mm*nn, MPI_DOUBLE_PRECISION, MPI_SUM, 0, MPI_COMM_WORLD, info )
+      IF( info /= 0 ) CALL errore( 'reduce_base_real', 'error in mpi_reduce 1', info )
+    ELSE
+      CALL MPI_REDUCE( mat, mat, mm*nn, MPI_DOUBLE_PRECISION, MPI_SUM, 0, MPI_COMM_WORLD, info )
+      IF( info /= 0 ) CALL errore( 'reduce_base_real', 'error in mpi_reduce 1', info )
+    ENDIF
 #endif
   END SUBROUTINE
   !
@@ -230,7 +250,7 @@ MODULE mpi_thermal
     REAL(DP),INTENT(inout) :: tns(ll, mm,nn)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, tns, ll*mm*nn, MPI_DOUBLE_PRECISION, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -240,10 +260,10 @@ MODULE mpi_thermal
     REAL(DP),INTENT(inout) :: tns(ll, mm,nn, oo)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, tns, ll*mm*nn*oo, MPI_DOUBLE_PRECISION, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
-  
+
   !!  ! --------- ------------- --- -- -- -- - - - complex numbers follow
   SUBROUTINE mpi_bsum_zscl(scl)
     IMPLICIT NONE
@@ -251,7 +271,7 @@ MODULE mpi_thermal
 
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, scl, 1, MPI_DOUBLE_COMPLEX, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -261,7 +281,7 @@ MODULE mpi_thermal
     COMPLEX(DP),INTENT(inout) :: vec(nn)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, vec, nn, MPI_DOUBLE_COMPLEX, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -271,7 +291,7 @@ MODULE mpi_thermal
     COMPLEX(DP),INTENT(inout) :: mat(mm,nn)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, mat, mm*nn, MPI_DOUBLE_COMPLEX, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -281,7 +301,7 @@ MODULE mpi_thermal
     COMPLEX(DP),INTENT(inout) :: tns(ll, mm,nn)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, tns, ll*mm*nn, MPI_DOUBLE_COMPLEX, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -291,7 +311,7 @@ MODULE mpi_thermal
     COMPLEX(DP),INTENT(inout) :: tns4(ll, mm,nn, oo)
 #ifdef __MPI
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, tns4, ll*mm*nn*oo, MPI_DOUBLE_COMPLEX, MPI_SUM,&
-                       MPI_COMM_WORLD, ierr)
+      MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE
   !
@@ -486,9 +506,36 @@ MODULE mpi_thermal
 !    ! do nothing
 !#endif
 !  END SUBROUTINE
-  
-  
-   ! Scatter in-place a matrix, along the second dimension
+
+  SUBROUTINE scatteri_mat_cmplx(mm, nn, mat)
+    IMPLICIT NONE
+    INTEGER,INTENT(in)  :: mm
+    INTEGER,INTENT(inout)  :: nn
+    COMPLEX(DP),INTENT(inout),ALLOCATABLE :: mat(:,:)
+    !
+    INTEGER  :: nn_send, nn_recv
+    COMPLEX(DP),ALLOCATABLE :: mat_send(:,:), mat_recv(:,:)
+    !
+    IF(.not.allocated(mat)) CALL errore('scatteri_mat', 'input matrix must be allocated', 1)
+    IF(size(mat,1)/=mm)      CALL errore('scatteri_mat', 'input matrix must be of size mm*nn', 2)
+    IF(size(mat,2)/=nn)      CALL errore('scatteri_mat', 'input matrix must be of size mm*nn', 3)
+    !
+#ifdef __MPI
+    nn_send = nn
+    ALLOCATE(mat_send(mm,nn_send))
+    mat_send(:,1:nn_send) = mat(:,1:nn_Send)
+    CALL scatter_mat_cmplx(mm,nn_send, mat_send, nn_recv, mat_recv)
+    DEALLOCATE(mat)
+    ALLOCATE(mat(mm,nn_recv))
+    mat(:,1:nn_recv) = mat_recv(:,1:nn_recv)
+    nn = nn_recv
+    DEALLOCATE(mat_send, mat_recv)
+#else
+    ! do nothing
+#endif
+  END SUBROUTINE
+
+  ! Scatter in-place a matrix, along the second dimension
   SUBROUTINE scatteri_mat(mm, nn, mat)
     IMPLICIT NONE
     INTEGER,INTENT(in)  :: mm
@@ -516,14 +563,89 @@ MODULE mpi_thermal
     ! do nothing
 #endif
   END SUBROUTINE
- 
+  !
+  SUBROUTINE scatter_tns(mm, ll, nn_send, mat_send, nn_recv, mat_recv)
+    IMPLICIT NONE
+    INTEGER,INTENT(in)  :: mm, ll, nn_send
+    REAL(DP),INTENT(in) :: mat_send(mm,ll,nn_send)
+    INTEGER,INTENT(out)  :: nn_recv
+    REAL(DP),ALLOCATABLE,INTENT(out) :: mat_recv(:,:,:)
+    !
+    INTEGER :: nn_residual, i
+    INTEGER,ALLOCATABLE  :: nn_scatt(:), ii_scatt(:)
+    CHARACTER(len=11),PARAMETER :: sub='scatter_mat'
+    !
+    IF(.not.mpi_started) CALL errore(sub, 'MPI not started', 1)
+!    IF(num_procs>nn_send) CALL errore(sub, 'num_procs > nn_send, this can work but makes no sense', 1)
+
+#ifdef __MPI
+    ALLOCATE(nn_scatt(num_procs))
+    ALLOCATE(ii_scatt(num_procs))
+
+    nn_recv = INT(nn_send/num_procs)
+    nn_residual = nn_send - nn_recv*num_procs
+    nn_scatt=nn_recv
+    IF(nn_residual>0) nn_scatt(1:nn_residual) = nn_scatt(1:nn_residual) +1
+    nn_recv = nn_scatt(my_id+1)
+    IF(allocated(mat_recv)) DEALLOCATE(mat_recv)
+    ALLOCATE(mat_recv(mm,ll,nn_recv))
+    !
+    ! account for the first dimension:
+    nn_scatt=nn_scatt*mm*ll
+    !
+    ii_scatt = 0
+    DO i = 2,num_procs
+       ii_scatt(i) = ii_scatt(i-1)+nn_scatt(i-1)
+    ENDDO
+    !
+    CALL MPI_scatterv(mat_send, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
+       mat_recv, nn_scatt(my_id+1), MPI_DOUBLE_PRECISION, &
+       0, MPI_COMM_WORLD, ierr )
+#else
+    nn_recv = nn_send
+    IF(allocated(mat_recv)) DEALLOCATE(mat_recv)
+    ALLOCATE(mat_recv(mm,ll,nn_recv))
+    mat_recv = mat_send
+#endif
+
+ END SUBROUTINE
+ !
+  SUBROUTINE scatteri_tns(mm, ll, nn, mat)
+    IMPLICIT NONE
+    INTEGER,INTENT(in)  :: mm, ll
+    INTEGER,INTENT(in)  :: nn
+    REAL(DP),INTENT(inout),ALLOCATABLE :: mat(:,:,:)
+    !
+    INTEGER  :: nn_send, nn_recv
+    REAL(DP),ALLOCATABLE :: mat_send(:,:,:), mat_recv(:,:,:)
+    !
+    IF(.not.allocated(mat)) CALL errore('scatteri_mat', 'input matrix must be allocated', 1)
+    IF(size(mat,1)/=mm)      CALL errore('scatteri_mat', 'input matrix must be of size mm*ll*nn', 2)
+    IF(size(mat,2)/=ll)      CALL errore('scatteri_mat', 'input matrix must be of size mm*ll*nn', 3)
+    IF(size(mat,3)/=nn)      CALL errore('scatteri_mat', 'input matrix must be of size mm*ll*nn', 4)
+
+    !
+#ifdef __MPI
+    nn_send = nn
+    ALLOCATE(mat_send(mm,ll,nn_send))
+    mat_send(:,:,1:nn_send) = mat(:,:,1:nn_Send)
+    CALL scatter_tns(mm, ll, nn_send, mat_send, nn_recv, mat_recv)
+    DEALLOCATE(mat)
+    ALLOCATE(mat(mm,ll,nn_recv))
+    mat(:,:,1:nn_recv) = mat_recv(:,:,1:nn_recv)
+    DEALLOCATE(mat_send, mat_recv)
+#else
+    ! do nothing
+#endif
+ END SUBROUTINE
+
   ! Divide a vector among all the CPUs
   SUBROUTINE scatter_vec(nn_send, vec_send, nn_recv, vec_recv, ii_recv)
     IMPLICIT NONE
     INTEGER,INTENT(in)  :: nn_send
     REAL(DP),INTENT(in) :: vec_send(nn_send)
     INTEGER,INTENT(out)  :: nn_recv
-    REAL(DP),ALLOCATABLE,INTENT(out) :: vec_recv(:) 
+    REAL(DP),ALLOCATABLE,INTENT(out) :: vec_recv(:)
     INTEGER,OPTIONAL,INTENT(out)  :: ii_recv
     !
     INTEGER :: nn_residual, i
@@ -540,20 +662,20 @@ MODULE mpi_thermal
     nn_recv = INT(nn_send/num_procs)
     nn_residual = nn_send - nn_recv*num_procs
     nn_scatt=nn_recv
-    IF(nn_residual>0) nn_scatt(1:nn_residual) = nn_scatt(1:nn_residual) +1 
+    IF(nn_residual>0) nn_scatt(1:nn_residual) = nn_scatt(1:nn_residual) +1
     nn_recv = nn_scatt(my_id+1)
     IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
     ALLOCATE(vec_recv(nn_recv))
 
     ii_scatt = 0
     DO i = 2,num_procs
-     ii_scatt(i) = ii_scatt(i-1)+nn_scatt(i-1)
+      ii_scatt(i) = ii_scatt(i-1)+nn_scatt(i-1)
     ENDDO
     IF(present(ii_recv)) ii_recv = ii_scatt(my_id+1)
 
     CALL MPI_scatterv(vec_send, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
-                      vec_recv, nn_recv, MPI_DOUBLE_PRECISION, &
-                      0, MPI_COMM_WORLD, ierr )
+      vec_recv, nn_recv, MPI_DOUBLE_PRECISION, &
+      0, MPI_COMM_WORLD, ierr )
     DEALLOCATE(nn_scatt, ii_scatt)
 #else
     nn_recv = nn_send
@@ -569,7 +691,7 @@ MODULE mpi_thermal
     IMPLICIT NONE
     INTEGER,INTENT(in)  :: nn_send
     REAL(DP),INTENT(in) :: vec_send(nn_send)
-    REAL(DP),INTENT(out) :: vec_recv(:) 
+    REAL(DP),INTENT(out) :: vec_recv(:)
     !INTEGER,OPTIONAL,INTENT(out)  :: ii_recv
     !
     !INTEGER :: nn_summed, i
@@ -603,8 +725,8 @@ MODULE mpi_thermal
 !    print*, "ALLGATHER",  my_id, nn_send, nn_recv, size(vec_send), size(vec_recv)
 
     CALL MPI_allgatherv(vec_send, nn_send, MPI_DOUBLE_PRECISION, &
-                        vec_recv, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
-                        MPI_COMM_WORLD, ierr )
+      vec_recv, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
+      MPI_COMM_WORLD, ierr )
 #else
     !nn_recv = nn_send
     !IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
@@ -619,7 +741,7 @@ MODULE mpi_thermal
     IMPLICIT NONE
     INTEGER,INTENT(in)  :: nn_send
     REAL(DP),INTENT(in) :: vec_send(nn_send)
-    REAL(DP),ALLOCATABLE,INTENT(out) :: vec_recv(:) 
+    REAL(DP),ALLOCATABLE,INTENT(out) :: vec_recv(:)
     !INTEGER,OPTIONAL,INTENT(out)  :: ii_recv
     !
     !INTEGER :: nn_summed, i
@@ -651,11 +773,11 @@ MODULE mpi_thermal
     ENDIF
     !WRITE(*,'(99i6)'), my_id, nn_scatt, ii_scatt
     !WRITE(*,'(99i6)'), my_id, nn_send, size(vec_send)
-    
+
 
     CALL MPI_gatherv(vec_send, nn_send, MPI_DOUBLE_PRECISION, &
-                      vec_recv, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
-                      0, MPI_COMM_WORLD, ierr )
+      vec_recv, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
+      0, MPI_COMM_WORLD, ierr )
 #else
     nn_recv = nn_send
     IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
@@ -668,8 +790,8 @@ MODULE mpi_thermal
   SUBROUTINE gather_mat(mm, nn_send, vec_send, vec_recv) !, ii_recv)
     IMPLICIT NONE
     INTEGER,INTENT(in)  :: mm, nn_send
-    REAL(DP),INTENT(in) :: vec_send(nn_send)
-    REAL(DP),ALLOCATABLE,INTENT(out) :: vec_recv(:,:) 
+    REAL(DP),INTENT(in) :: vec_send(mm,nn_send)
+    REAL(DP),ALLOCATABLE,INTENT(out) :: vec_recv(:,:)
     !INTEGER,OPTIONAL,INTENT(out)  :: ii_recv
     !
     !INTEGER :: nn_summed, i
@@ -692,7 +814,7 @@ MODULE mpi_thermal
     CALL mpi_bsum(num_procs, ii_scatt)
     nn_recv = nn_send
     CALL mpi_bsum(nn_recv)
-    
+
 
     IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
     IF(my_id==0) THEN
@@ -702,29 +824,29 @@ MODULE mpi_thermal
     ENDIF
     !WRITE(*,'(99i6)'), my_id, nn_scatt, ii_scatt
     !WRITE(*,'(99i6)'), my_id, nn_send, size(vec_send)
-    
+
     nn_scatt = nn_scatt*mm
     ii_scatt = ii_scatt*mm
     mmnn_send = nn_send*mm
 
     CALL MPI_gatherv(vec_send, mmnn_send, MPI_DOUBLE_PRECISION, &
-                     vec_recv, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
-                     0, MPI_COMM_WORLD, ierr )
+      vec_recv, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
+      0, MPI_COMM_WORLD, ierr )
 #else
     nn_recv = nn_send
     IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
     ALLOCATE(vec_recv(mm,nn_recv))
     vec_recv = vec_send
 #endif
-  END SUBROUTINE  
-    
-  ! Divide a matrix, along the last dimension, among all the CPUs
-  SUBROUTINE scatter_mat(mm, nn_send, mat_send, nn_recv, mat_recv)
+  END SUBROUTINE
+
+! Divide a matrix, along the last dimension, among all the CPUs
+  SUBROUTINE scatter_mat_cmplx(mm, nn_send, mat_send, nn_recv, mat_recv)
     IMPLICIT NONE
     INTEGER,INTENT(in)  :: mm, nn_send
-    REAL(DP),INTENT(in) :: mat_send(mm,nn_send)
+    COMPLEX(DP),INTENT(in) :: mat_send(mm,nn_send)
     INTEGER,INTENT(out)  :: nn_recv
-    REAL(DP),ALLOCATABLE,INTENT(out) :: mat_recv(:,:) 
+    COMPLEX(DP),ALLOCATABLE,INTENT(out) :: mat_recv(:,:)
     !
     INTEGER :: nn_residual, i
     INTEGER,ALLOCATABLE  :: nn_scatt(:), ii_scatt(:)
@@ -740,7 +862,7 @@ MODULE mpi_thermal
     nn_recv = INT(nn_send/num_procs)
     nn_residual = nn_send - nn_recv*num_procs
     nn_scatt=nn_recv
-    IF(nn_residual>0) nn_scatt(1:nn_residual) = nn_scatt(1:nn_residual) +1 
+    IF(nn_residual>0) nn_scatt(1:nn_residual) = nn_scatt(1:nn_residual) +1
     nn_recv = nn_scatt(my_id+1)
     IF(allocated(mat_recv)) DEALLOCATE(mat_recv)
     ALLOCATE(mat_recv(mm,nn_recv))
@@ -750,22 +872,153 @@ MODULE mpi_thermal
     !
     ii_scatt = 0
     DO i = 2,num_procs
-     ii_scatt(i) = ii_scatt(i-1)+nn_scatt(i-1)
+      ii_scatt(i) = ii_scatt(i-1)+nn_scatt(i-1)
     ENDDO
     !
-    CALL MPI_scatterv(mat_send, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
-                      mat_recv, nn_scatt(my_id+1), MPI_DOUBLE_PRECISION, &
-                      0, MPI_COMM_WORLD, ierr )
+    CALL MPI_scatterv(mat_send, nn_scatt, ii_scatt, MPI_DOUBLE_COMPLEX, &
+      mat_recv, nn_scatt(my_id+1), MPI_DOUBLE_COMPLEX, &
+      0, MPI_COMM_WORLD, ierr )
 #else
     nn_recv = nn_send
     IF(allocated(mat_recv)) DEALLOCATE(mat_recv)
     ALLOCATE(mat_recv(mm,nn_recv))
     mat_recv = mat_send
 #endif
-    
+
   END SUBROUTINE
 
+  ! Divide a matrix, along the last dimension, among all the CPUs
+  SUBROUTINE scatter_mat(mm, nn_send, mat_send, nn_recv, mat_recv)
+    IMPLICIT NONE
+    INTEGER,INTENT(in)  :: mm, nn_send
+    REAL(DP),INTENT(in) :: mat_send(mm,nn_send)
+    INTEGER,INTENT(out)  :: nn_recv
+    REAL(DP),ALLOCATABLE,INTENT(out) :: mat_recv(:,:)
+    !
+    INTEGER :: nn_residual, i
+    INTEGER,ALLOCATABLE  :: nn_scatt(:), ii_scatt(:)
+    CHARACTER(len=11),PARAMETER :: sub='scatter_mat'
+    !
+    IF(.not.mpi_started) CALL errore(sub, 'MPI not started', 1)
+!    IF(num_procs>nn_send) CALL errore(sub, 'num_procs > nn_send, this can work but makes no sense', 1)
 
+#ifdef __MPI
+    ALLOCATE(nn_scatt(num_procs))
+    ALLOCATE(ii_scatt(num_procs))
+
+    nn_recv = INT(nn_send/num_procs)
+    nn_residual = nn_send - nn_recv*num_procs
+    nn_scatt=nn_recv
+    IF(nn_residual>0) nn_scatt(1:nn_residual) = nn_scatt(1:nn_residual) +1
+    nn_recv = nn_scatt(my_id+1)
+    IF(allocated(mat_recv)) DEALLOCATE(mat_recv)
+    ALLOCATE(mat_recv(mm,nn_recv))
+    !
+    ! account for the first dimension:
+    nn_scatt=nn_scatt*mm
+    !
+    ii_scatt = 0
+    DO i = 2,num_procs
+      ii_scatt(i) = ii_scatt(i-1)+nn_scatt(i-1)
+    ENDDO
+    !
+    CALL MPI_scatterv(mat_send, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
+      mat_recv, nn_scatt(my_id+1), MPI_DOUBLE_PRECISION, &
+      0, MPI_COMM_WORLD, ierr )
+#else
+    nn_recv = nn_send
+    IF(allocated(mat_recv)) DEALLOCATE(mat_recv)
+    ALLOCATE(mat_recv(mm,nn_recv))
+    mat_recv = mat_send
+#endif
+
+  END SUBROUTINE
+
+  SUBROUTINE allgather_mat(mm, nn_send, vec_send, vec_recv)
+    IMPLICIT NONE
+    INTEGER, INTENT(in)  :: mm, nn_send
+    REAL(DP), INTENT(in) :: vec_send(mm, nn_send)
+    REAL(DP), ALLOCATABLE, INTENT(out) :: vec_recv(:,:)
+    !
+    INTEGER :: nn_recv, mmnn_send
+    INTEGER,ALLOCATABLE :: nn_scatt(:), ii_scatt(:)
+    CHARACTER(13),PARAMETER :: sub='allgather_mat'
+    !
+    IF(.not.mpi_started) CALL errore(sub, 'MPI not started', 1)
+
+#ifdef __MPI
+    ALLOCATE(nn_scatt(num_procs))
+    ALLOCATE(ii_scatt(num_procs))
+
+    nn_scatt = 0
+    nn_scatt(my_id+1) = nn_send
+    CALL mpi_bsum(num_procs, nn_scatt)
+    ii_scatt = 0
+    ii_scatt(my_id+1) = SUM(nn_scatt(1:my_id))
+    CALL mpi_bsum(num_procs, ii_scatt)
+    nn_recv = nn_send
+    CALL mpi_bsum(nn_recv)
+
+    IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
+    ALLOCATE(vec_recv(mm, nn_recv))
+
+    nn_scatt = nn_scatt * mm
+    ii_scatt = ii_scatt * mm
+    mmnn_send = nn_send * mm
+
+    CALL MPI_Allgatherv(vec_send, mmnn_send, MPI_DOUBLE_PRECISION, &
+      vec_recv, nn_scatt, ii_scatt, MPI_DOUBLE_PRECISION, &
+      MPI_COMM_WORLD, ierr)
+#else
+    nn_recv = nn_send
+    IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
+    ALLOCATE(vec_recv(mm, nn_recv))
+    vec_recv = vec_send
+#endif
+  END SUBROUTINE allgather_mat
+
+  SUBROUTINE allgather_tns_cmplx(ll, mm, nn_send, vec_send, vec_recv)
+    IMPLICIT NONE
+    INTEGER, INTENT(in)  :: ll, mm, nn_send
+    COMPLEX(DP), INTENT(in) :: vec_send(ll, mm, nn_send)
+    COMPLEX(DP), ALLOCATABLE, INTENT(out) :: vec_recv(:,:,:)
+    !
+    INTEGER :: nn_recv, mmnn_send
+    INTEGER,ALLOCATABLE :: nn_scatt(:), ii_scatt(:)
+    CHARACTER(13),PARAMETER :: sub='allgather_mat'
+    !
+    IF(.not.mpi_started) CALL errore(sub, 'MPI not started', 1)
+
+#ifdef __MPI
+    ALLOCATE(nn_scatt(num_procs))
+    ALLOCATE(ii_scatt(num_procs))
+
+    nn_scatt = 0
+    nn_scatt(my_id+1) = nn_send
+    CALL mpi_bsum(num_procs, nn_scatt)
+    ii_scatt = 0
+    ii_scatt(my_id+1) = SUM(nn_scatt(1:my_id))
+    CALL mpi_bsum(num_procs, ii_scatt)
+    nn_recv = nn_send
+    CALL mpi_bsum(nn_recv)
+
+    IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
+    ALLOCATE(vec_recv(ll, mm, nn_recv))
+
+    nn_scatt = nn_scatt * mm * ll
+    ii_scatt = ii_scatt * mm * ll
+    mmnn_send = nn_send * mm * ll
+
+    CALL MPI_Allgatherv(vec_send, mmnn_send, MPI_DOUBLE_COMPLEX, &
+      vec_recv, nn_scatt, ii_scatt, MPI_DOUBLE_COMPLEX, &
+      MPI_COMM_WORLD, ierr)
+#else
+    nn_recv = nn_send
+    IF(allocated(vec_recv)) DEALLOCATE(vec_recv)
+    ALLOCATE(vec_recv(ll, mm, nn_recv))
+    vec_recv = vec_send
+#endif
+  END SUBROUTINE
 
 END MODULE mpi_thermal
 

--- a/thermal2/thtetra.f90
+++ b/thermal2/thtetra.f90
@@ -1,0 +1,860 @@
+!
+! This module is rewritten from the tetra.f90 in PW/src
+!
+MODULE thtetra
+   !
+   ! Tetrahedron method, linear and optimized. opt is better for all purpose
+   ! weights for delta integration are obtained by multiplying gi with Iik in
+   ! https://iopscience.iop.org/article/10.1088/0022-3719/12/15/008
+   !
+   ! another useful link, for delta integration where the integrand is 1 (DOS)
+   ! http://staff.ustc.edu.cn/~zqj/posts/LinearTetrahedronMethod/#fn:tet_weight
+   !
+   ! optimized tetrahedron method, used in QE for theta integration in opt_tetra_weights
+   ! https://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.094515
+   ! they multiply ni with Jik in the first article, then they transform (fit) through wlsm matrices
+   USE kinds, ONLY: DP
+   USE mpi_thermal, ONLY: my_id, num_procs, mpi_bsum
+   !
+   IMPLICIT NONE
+   !
+   PRIVATE
+   SAVE
+   !
+   INTEGER :: ntetra = 0
+   !! number of tetrahedra
+   INTEGER :: nntetra
+   !! k-points per tetrahedron used to compute weights.
+   !! 4 for linear / 20 for optimized tetrahedron method
+   INTEGER, ALLOCATABLE :: tetra(:,:)
+   !! index of k-points in a given tetrahedron shape (nntetra,ntetra)
+   REAL(DP), ALLOCATABLE :: wlsm(:,:)
+   !! Weights for the optimized tetrahedron method
+   INTEGER :: nqs
+   !! number of q-points
+   INTEGER :: nbnd
+   !! number of bands
+   INTEGER, ALLOCATABLE :: itetra(:,:,:)
+   !! order index of vertices of each tetrahedron (4,nbnd,ntetra)
+   REAL(DP), ALLOCATABLE :: ek_sort(:,:,:)
+   !! sorted energies for each tetrahedron (4,nbnd,ntetra)
+   ! INTEGER, allocatable :: which_tetra(:,:,:)
+   !! inverse of tetra: given a q point, it gives all the tetrahedra that contain it
+
+   REAL(DP), PARAMETER :: tet_cutoff = 1.0E-4_DP
+   LOGICAL :: opt_flag
+   !
+   PUBLIC :: tetra, ntetra, nntetra, wlsm, tetra_weights_green
+   PUBLIC :: tetra_init, deallocate_tetra, tetra_weights_delta
+   PUBLIC :: tetra_weights_delta_vec, ek_sort
+   ! PUBLIC :: tetra_weights_delta, tetra_weights_theta, tetra_delta
+
+   EXTERNAL :: errore, hpsort
+
+   !
+CONTAINS
+   !
+   !--------------------------------------------------------------------------
+   SUBROUTINE tetra_init(nq, bg, ek)
+      !-----------------------------------------------------------------------------
+      !! This rouotine sets the corners and additional points for each tetrahedron.
+      !
+      IMPLICIT NONE
+      !
+      INTEGER, INTENT(IN) :: nq(3)
+      !! number of q-points in each direction
+      !
+      REAL(DP), INTENT(IN) :: bg(3,3)
+      !! Reciplocal lattice vectors [2 pi / a]
+      REAL(DP), INTENT(IN) :: ek(:,:)
+      !! energy in the form ek(ibnd, iq)
+      ! LOGICAL, INTENT(IN) :: is_mpi
+      !! if .true., the grid is scattered
+      ! LOGICAL, INTENT(IN), OPTIONAL :: opt
+      ! !! if .true., uses opt_tetra methods
+
+      REAL(DP), PARAMETER :: eps = 1e-5_dp
+      !
+      INTEGER :: i1, i2, i3, itet, itettot, ii, ik,  &
+         ivvec(3,20,6), divvec(4,4), ivvec0(4), ikv(3), ibnd
+      ! integer :: tetra_ik(nq(1) * nq(2) * nq(3))
+      !
+      REAL(DP) :: l(4), bvec2(3,3), bvec3(3,4)
+
+      IF(ntetra /= 0) CALL deallocate_tetra()
+      !
+      nbnd = SIZE(ek,1)
+      nqs = nq(1) * nq(2) * nq(3)
+      !
+      IF(nqs /= SIZE(ek,2)) CALL errore("tetra_init", "n(1) * n(2) * n(3) /= SIZE(ek,2)", SIZE(ek,2))
+      ntetra  = 6*nqs
+      !
+      ALLOCATE(ek_sort(4,nbnd,ntetra))
+      ek_sort = 0.0_dp
+      ALLOCATE(itetra (4,nbnd,ntetra))
+      ! ALLOCATE(which_tetra (2,nqs,24))
+      !
+      opt_flag = .true.
+      ! if(PRESENT(opt)) opt_flag = opt
+      !
+      ! Take the shortest diagonal line as the "shaft" of tetrahedral devision
+      !
+      bvec2(1:3,1) = bg(1:3,1) / REAL(nq(1), dp)
+      bvec2(1:3,2) = bg(1:3,2) / REAL(nq(2), dp)
+      bvec2(1:3,3) = bg(1:3,3) / REAL(nq(3), dp)
+      !
+      bvec3(1:3,1) = -bvec2(1:3,1) + bvec2(1:3,2) + bvec2(1:3,3)
+      bvec3(1:3,2) =  bvec2(1:3,1) - bvec2(1:3,2) + bvec2(1:3,3)
+      bvec3(1:3,3) =  bvec2(1:3,1) + bvec2(1:3,2) - bvec2(1:3,3)
+      bvec3(1:3,4) =  bvec2(1:3,1) + bvec2(1:3,2) + bvec2(1:3,3)
+      !
+      DO ii = 1, 4
+         l(ii) = DOT_PRODUCT(bvec3(1:3, ii), bvec3(1:3, ii))
+      ENDDO
+      !
+      ii = MINLOC(l(1:4),1)
+      !
+      ivvec0(1:4) = (/ 0, 0, 0, 0 /)
+      !
+      divvec(1:4,1) = (/ 1, 0, 0, 0 /)
+      divvec(1:4,2) = (/ 0, 1, 0, 0 /)
+      divvec(1:4,3) = (/ 0, 0, 1, 0 /)
+      divvec(1:4,4) = (/ 0, 0, 0, 1 /)
+      !
+      ivvec0(ii) = 1
+      divvec(ii, ii) = - 1
+      !
+      ! Divide a subcell into 6 tetrahedra
+      !
+      itet = 0
+      DO i1 = 1, 3
+         DO i2 = 1, 3
+            IF(i2 == i1) CYCLE
+            DO i3 = 1, 3
+               IF(i3 == i1 .OR. i3 == i2) CYCLE
+               !
+               itet = itet + 1
+               !
+               ivvec(1:3,1,itet) = ivvec0(1:3)
+               ivvec(1:3,2,itet) = ivvec(1:3,1,itet) + divvec(1:3,i1)
+               ivvec(1:3,3,itet) = ivvec(1:3,2,itet) + divvec(1:3,i2)
+               ivvec(1:3,4,itet) = ivvec(1:3,3,itet) + divvec(1:3,i3)
+               !
+            ENDDO
+         ENDDO
+      ENDDO
+      !
+      ! Additional points surrounding the tetrahedron
+      !
+      ivvec(1:3, 5,1:6) = 2 * ivvec(1:3,1,1:6) - ivvec(1:3,2,1:6)
+      ivvec(1:3, 6,1:6) = 2 * ivvec(1:3,2,1:6) - ivvec(1:3,3,1:6)
+      ivvec(1:3, 7,1:6) = 2 * ivvec(1:3,3,1:6) - ivvec(1:3,4,1:6)
+      ivvec(1:3, 8,1:6) = 2 * ivvec(1:3,4,1:6) - ivvec(1:3,1,1:6)
+      !
+      ivvec(1:3, 9,1:6) = 2 * ivvec(1:3,1,1:6) - ivvec(1:3,3,1:6)
+      ivvec(1:3,10,1:6) = 2 * ivvec(1:3,2,1:6) - ivvec(1:3,4,1:6)
+      ivvec(1:3,11,1:6) = 2 * ivvec(1:3,3,1:6) - ivvec(1:3,1,1:6)
+      ivvec(1:3,12,1:6) = 2 * ivvec(1:3,4,1:6) - ivvec(1:3,2,1:6)
+      !
+      ivvec(1:3,13,1:6) = 2 * ivvec(1:3,1,1:6) - ivvec(1:3,4,1:6)
+      ivvec(1:3,14,1:6) = 2 * ivvec(1:3,2,1:6) - ivvec(1:3,1,1:6)
+      ivvec(1:3,15,1:6) = 2 * ivvec(1:3,3,1:6) - ivvec(1:3,2,1:6)
+      ivvec(1:3,16,1:6) = 2 * ivvec(1:3,4,1:6) - ivvec(1:3,3,1:6)
+      !
+      ivvec(1:3,17,1:6) =  ivvec(1:3,4,1:6) - ivvec(1:3,1,1:6) + ivvec(1:3,2,1:6)
+      ivvec(1:3,18,1:6) =  ivvec(1:3,1,1:6) - ivvec(1:3,2,1:6) + ivvec(1:3,3,1:6)
+      ivvec(1:3,19,1:6) =  ivvec(1:3,2,1:6) - ivvec(1:3,3,1:6) + ivvec(1:3,4,1:6)
+      ivvec(1:3,20,1:6) =  ivvec(1:3,3,1:6) - ivvec(1:3,4,1:6) + ivvec(1:3,1,1:6)
+      !
+      ! Set the weight for the each tetrahedron method
+      !
+      ! WRITE(stdout,*) "    [opt_tetra]  Optimized tetrahedron method is used."
+      !
+      IF (opt_flag) THEN
+         !
+         nntetra = 20
+         IF (.NOT. ALLOCATED(tetra)) ALLOCATE( tetra(nntetra,ntetra) )
+         IF (.NOT. ALLOCATED(wlsm))  ALLOCATE( wlsm(4,nntetra) )
+         !
+         wlsm(1, 1: 4) = REAL((/1440,    0,   30,    0/), dp)
+         wlsm(2, 1: 4) = REAL((/   0, 1440,    0,   30/), dp)
+         wlsm(3, 1: 4) = REAL((/  30,    0, 1440,    0/), dp)
+         wlsm(4, 1: 4) = REAL((/   0,   30,    0, 1440/), dp)
+         !
+         wlsm(1, 5: 8) = REAL((/ -38,    7,   17,  -28/), dp)
+         wlsm(2, 5: 8) = REAL((/ -28,  -38,    7,   17/), dp)
+         wlsm(3, 5: 8) = REAL((/  17,  -28,  -38,    7/), dp)
+         wlsm(4, 5: 8) = REAL((/   7,   17,  -28,  -38/), dp)
+         !
+         wlsm(1, 9:12) = REAL((/ -56,    9,  -46,    9/), dp)
+         wlsm(2, 9:12) = REAL((/   9,  -56,    9,  -46/), dp)
+         wlsm(3, 9:12) = REAL((/ -46,    9,  -56,    9/), dp)
+         wlsm(4, 9:12) = REAL((/   9,  -46,    9,  -56/), dp)
+         !
+         wlsm(1,13:16) = REAL((/ -38,  -28,   17,    7/), dp)
+         wlsm(2,13:16) = REAL((/   7,  -38,  -28,   17/), dp)
+         wlsm(3,13:16) = REAL((/  17,    7,  -38,  -28/), dp)
+         wlsm(4,13:16) = REAL((/ -28,   17,    7,  -38/), dp)
+         !
+         wlsm(1,17:20) = REAL((/ -18,  -18,   12,  -18/), dp)
+         wlsm(2,17:20) = REAL((/ -18,  -18,  -18,   12/), dp)
+         wlsm(3,17:20) = REAL((/  12,  -18,  -18,  -18/), dp)
+         wlsm(4,17:20) = REAL((/ -18,   12,  -18,  -18/), dp)
+         !
+         wlsm(1:4,1:20) = wlsm(1:4,1:20) / 1260.0_dp
+         !
+      ELSE
+         !
+         nntetra = 4
+         IF(.NOT. ALLOCATED(tetra)) ALLOCATE ( tetra(nntetra,ntetra) )
+         IF(.NOT. ALLOCATED(wlsm))  ALLOCATE ( wlsm(4,nntetra) )
+         wlsm(:,:) = 0.0_dp
+         !
+         wlsm(1,1) = 1.0_dp
+         wlsm(2,2) = 1.0_dp
+         wlsm(3,3) = 1.0_dp
+         wlsm(4,4) = 1.0_dp
+         !
+      ENDIF
+
+      !
+      !  locate k-points of the uniform grid in the list of irreducible k-points
+      !  that was previously calculated
+      !
+      !  bring irreducible k-points to crystal axis
+      !
+      ! Construct tetrahedra
+      !
+      itettot = 0
+      ! tetra_ik = 0
+      DO i1 = 1, nq(1)
+         DO i2 = 1, nq(2)
+            DO i3 = 1, nq(3)
+               !
+               DO itet = 1, 6
+                  !
+                  itettot = itettot + 1
+                  DO ibnd = 1, nbnd
+                     !
+                     DO ii = 1, nntetra
+                        !
+                        ikv(1:3) = (/i1, i2, i3/) - 1
+                        ikv(1:3) = ikv(1:3) + ivvec(1:3,ii,itet)
+                        ikv(1:3) = MODULO(ikv(1:3), (/nq(1), nq(2), nq(3)/))
+                        !
+                        ik = ikv(3) + nq(3) * (ikv(2) + nq(2) * ikv(1)) + 1
+                        !
+                        ! if(ii <= 4) then
+                        !    tetra_ik(ik) = tetra_ik(ik) + 1
+                        !    which_tetra(1, ik, tetra_ik(ik)) = itettot
+                        !    which_tetra(2, ik, tetra_ik(ik)) = ii
+                        ! endif
+                        tetra(ii, itettot) = ik
+                        !
+                        ! IF(opt_flag) THEN
+                           ek_sort(:,ibnd,itettot) = ek_sort(:,ibnd,itettot) + wlsm(:,ii) * ek(ibnd,ik)
+                        ! ELSE
+                        !    ek_sort(ii,ibnd,itettot) = ek(ibnd,ik)
+                        ! ENDIF
+
+                     END DO ! ii
+                     !
+                     !
+                     itetra(1,ibnd,itettot) = 0 ! needed to initialize index inside hpsort
+                     CALL hpsort( 4, ek_sort(:,ibnd,itettot), itetra(:,ibnd,itettot))
+                  ENDDO ! ibnd
+                  !
+               ENDDO ! itet
+               !
+            ENDDO ! i3
+         ENDDO ! i2
+      ENDDO ! i1
+      !
+   END SUBROUTINE tetra_init
+   !
+   !--------------------------------------------------------------------------------------
+   ! FUNCTION tetra_delta( nqs, nbnd, et, ef) RESULT(w)
+   !   !-----------------------------------------------------------------------------------
+   !   !! Calculate the area of the implicit surface for an integrals of the kind int(Ak delta(ef-ek))
+   !   !! usage: create a grid of points around a point in which you know Ak, this function gives the area
+   !   !! and it's the same as sum(tetra_weights_delta) over the grid
+   !   !-----------------------------------------------------------------------------------
+   !   INTEGER, INTENT(IN) :: nqs
+   !   !! The total # of k in irr-BZ
+   !   INTEGER, INTENT(IN) :: nbnd
+   !   !! The # of bands
+   !   REAL(DP), INTENT(IN) :: et(nbnd,nqs)
+   !   !! Kohn Sham energy [Ry]
+   !   REAL(DP) :: w(nbnd)
+   !   !! Integration weight of each k
+   !   REAL(DP), INTENT(IN) :: ef
+   !   !! The Fermi energy
+   !   !
+   !   ! ... local variables
+   !   !
+   !   INTEGER :: ik, nt, ibnd, i, ii, itetra(4), my_id_, num_procs_
+   !   REAL(DP) :: e(4), C, a(4,4)
+
+   !   EXTERNAL hpsort
+   !   !
+   !   w = 0._dp
+   !   !
+   !   IF(is_mpi_flag) THEN
+   !     my_id_ = my_id
+   !     num_procs_ = num_procs
+   !   ELSE
+   !     my_id_ = 0
+   !     num_procs_ = 1
+   !   ENDIF
+   !   DO nt = 1+my_id_, ntetra, num_procs_
+   !     !
+   !     DO ibnd = 1, nbnd
+   !       !
+   !       e(1:4) = 0.0_dp
+   !       DO ii = 1, nntetra
+   !         !
+   !         ik = tetra(ii, nt)
+   !         IF(opt_flag) THEN
+   !           e(1:4) = e(1:4) + wlsm(1:4,ii) * et(ibnd,ik)
+   !         ELSE
+   !           e(ii) = et(ibnd,ik)
+   !         ENDIF
+   !         !
+   !       ENDDO
+   !       !
+   !       IF(MAXVAL(e) < ef .or. MINVAL(e) > ef) CYCLE
+   !       itetra(1) = 0
+   !       CALL hpsort( 4, e, itetra )
+   !       ! CALL quicksort_idx(e, itetra, 1, 4)
+   !       DO ii = 1, 4
+   !         DO i = 1, 4
+   !           IF ( ABS(e(i)-e(ii)) < 1.d-12 ) THEN
+   !             a(ii,i) = 0.0_dp
+   !           ELSE
+   !             a(ii,i) = ( ef - e(i) ) / (e(ii) - e(i) )
+   !           END IF
+   !         ENDDO
+   !       ENDDO
+   !       !
+   !       IF( e(1) < ef .AND. ef < e(2) ) THEN
+   !         !
+   !         C = 3 * a(2,1) * a(3,1) * a(4,1) / (ef - e(1))
+   !         !
+   !       ELSEIF( e(2) <= ef .AND. ef < e(3)) THEN
+   !         !
+   !         C = 3 * ( a(2,3) * a(3,1) + a(3,2) * a(2,4) ) / (e(4) - e(1))
+   !         !
+   !       ELSEIF ( e(3) <= ef .AND. ef < e(4)) THEN
+   !         !
+   !         C = 3 * a(1,4) * a(2,4) * a(3,4) / (e(4) - ef)
+   !         !
+   !       ENDIF
+   !       !
+   !       w(ibnd) = w(ibnd) + C
+   !       !
+   !     ENDDO ! ibnd
+   !     !
+   !   ENDDO ! nt
+   !   w = w / ntetra
+   !   !
+   !   ! I LEFT OUT THE PART OF AVERAGING OF DEGENERACIES
+   ! END FUNCTION tetra_delta
+   ! !--------------------------------------------------------------------------------------
+   FUNCTION tetra_weights_delta_vec(nef, ef) RESULT(wI)
+      USE constants, ONLY : pi
+      !-----------------------------------------------------------------------------------
+      !! Calculate weights for an integral of the kind int(Ak delta(ef-ek))
+      !! The resulting wg can be used as sum(Ak * wk)
+      !-----------------------------------------------------------------------------------
+      integer, intent(in) :: nef
+      !! size of vector ef
+      REAL(DP), INTENT(IN) :: ef(:)
+      !! The Fermi energy
+      REAL(DP) :: wI(nef, nbnd, nqs)
+      !! COMPLEX Integration weight of each k
+      !
+      !
+      INTEGER :: ik, nt, ibnd, ii, ief
+      REAL(DP) :: e(4), wI0(4)
+
+      ! for real part calc
+      ! REAL(DP) :: wR0(4), ef_e(4), log_ef_e(4), prod_a(4), sum_a(4), second_term(4)
+      ! INTEGER :: i3, j3
+      !
+      wI = 0._dp
+      !
+      DO nt = 1+my_id, ntetra, num_procs
+         !
+         DO ibnd = 1, nbnd
+            DO ief = 1, SIZE(ef)
+               !
+               e = ek_sort(:,ibnd,nt)
+               wI0 = delta_vertices(ef(ief), e)
+               !
+               DO ii = 1, nntetra
+                  !
+                  ik = tetra(ii, nt)
+                  ! IF(opt_flag) THEN
+                  wI(ief,ibnd,ik) = wI(ief,ibnd,ik) + DOT_PRODUCT(wlsm(itetra(:,ibnd,nt),ii), wI0(:))
+                  ! ELSE
+                  !   ik_s = tetra(itetra(ii,ibnd,nt), nt)
+                  !   wI(ibnd,ik_s) = wI(ibnd,ik_s) + wI0(ii)
+                  !   wR(ibnd,ik_s) = wR(ibnd,ik_s) + wR0(ii)
+                  ! ENDIF
+               ENDDO
+               !
+            ENDDO ! ief
+         ENDDO ! ibnd
+         !
+      ENDDO ! nt
+      ! wg = wg / REAL(ntetra, dp)
+      wI = wI / (6.0_dp * nqs)
+      !
+      ! I LEFT OUT THE PART OF AVERAGING OF DEGENERACIES
+      CALL mpi_bsum(nef, nbnd, nqs, wI)
+   END FUNCTION
+   !
+   FUNCTION tetra_weights_delta(ef) RESULT(wI)
+      USE constants, ONLY : pi
+      !-----------------------------------------------------------------------------------
+      !! Calculate weights for an integral of the kind int(Ak delta(ef-ek))
+      !! The resulting wg can be used as sum(Ak * wk)
+      !-----------------------------------------------------------------------------------
+      REAL(DP) :: wI(nbnd, nqs)
+      !! COMPLEX Integration weight of each k
+      REAL(DP), INTENT(IN) :: ef
+      !! The Fermi energy
+      INTEGER :: ik, nt, ibnd, ii
+      REAL(DP) :: e(4), wI0(4)
+
+      ! for real part calc
+      ! REAL(DP) :: wR0(4), ef_e(4), log_ef_e(4), prod_a(4), sum_a(4), second_term(4)
+      ! INTEGER :: i3, j3
+      !
+      wI = 0._dp
+      !
+      DO nt = 1+my_id, ntetra, num_procs
+         !
+         DO ibnd = 1, nbnd
+            !
+            e = ek_sort(:,ibnd,nt)
+            wI0 = delta_vertices(ef, e)
+            !
+            DO ii = 1, nntetra
+               !
+               ik = tetra(ii, nt)
+               ! IF(opt_flag) THEN
+               wI(ibnd,ik) = wI(ibnd,ik) + DOT_PRODUCT(wlsm(itetra(:,ibnd,nt),ii), wI0(:))
+               ! ELSE
+               !   ik_s = tetra(itetra(ii,ibnd,nt), nt)
+               !   wI(ibnd,ik_s) = wI(ibnd,ik_s) + wI0(ii)
+               !   wR(ibnd,ik_s) = wR(ibnd,ik_s) + wR0(ii)
+               ! ENDIF
+            ENDDO
+            !
+         ENDDO ! ibnd
+         !
+      ENDDO ! nt
+      ! wg = wg / REAL(ntetra, dp)
+      wI = wI / (6.0_dp * nqs)
+      !
+      ! I LEFT OUT THE PART OF AVERAGING OF DEGENERACIES
+      CALL mpi_bsum(nbnd, nqs, wI)
+   END FUNCTION
+
+   subroutine rm_degen_vertices(hw, D)
+      real(dp), INTENT(IN) :: hw
+      real(dp), INTENT(INOUT) :: D(4)
+      !
+      real(dp) :: DAV, D_small_prev, D_large_prev
+      !
+      DAV = (D(2) + D(3))/2.0_dp
+      if (abs((D(2) - D(3))/(DAV + hw)) < tet_cutoff) then
+         D_small_prev = D(2); D_large_prev = D(3)
+         D(3) = DAV + 0.5_dp*abs(DAV + hw)*tet_cutoff
+         D(2) = DAV - 0.5_dp*abs(DAV + hw)*tet_cutoff
+         if (D(1) > D(2)) D(1) = D(1) + (D(2) - D_small_prev)
+         if (D(3) > D(4)) D(4) = D(4) + (D(3) - D_large_prev)
+      endif
+      DAV = (D(1) + D(2))/2.0_dp
+      if (abs((D(1) - D(2))/(DAV + hw)) < tet_cutoff) then
+         if (D(2) > 0) then
+            D(1) = D(2)*(2.0_dp - tet_cutoff)/(2.0_dp + tet_cutoff)
+         else
+            D(1) = D(2)*(2.0_dp + tet_cutoff)/(2.0_dp - tet_cutoff)
+         endif
+      endif
+      DAV = (D(3) + D(4))/2.0_dp
+      if (abs((D(3) - D(4))/(DAV + hw)) < tet_cutoff) then
+         if (D(3) > 0) then
+            D(4) = D(3)*(2.0_dp + tet_cutoff)/(2.0_dp - tet_cutoff)
+         else
+            D(4) = D(3)*(2.0_dp - tet_cutoff)/(2.0_dp + tet_cutoff)
+         endif
+      endif
+   end subroutine
+   !
+   PURE FUNCTION real_vertices(hw, D) result(wR0)
+      !
+      real(dp), INTENT(IN) :: hw
+      real(dp), INTENT(IN) :: D(4)
+      !
+      real(dp) :: wR0(4)
+      real(dp) :: dd(3), ll(3), ff, bb(4), cc(4, 3)
+      integer :: a, b, c, i
+      !
+      ! intermediate variables for case 1 and 3
+      !
+      do i = 1, 3
+         dd(i) = (D(4) - D(i))/(D(i) + hw)
+         ll(i) = tetrahedron_log1p(dd(i))
+      enddo
+      !
+      ff = 1.0_dp
+      do i = 1, 3
+         a = i
+         b = mod(i, 3) + 1
+         c = mod(i + 1, 3) + 1
+         cc(a, a) = -(1.0_dp + dd(a))*(3.0_dp*dd(a)**2 - 2.0_dp*(dd(b) + dd(c))*dd(a) + dd(b)*dd(c)) &
+            *((dd(b) - dd(c))*dd(b)*dd(c))**2
+         cc(b, a) = -dd(a)*(1.0_dp + dd(b))*(dd(c) - dd(a))*((dd(b) - dd(c))*dd(b)*dd(c))**2
+         cc(c, a) = dd(a)*(1.0_dp + dd(c))*(dd(a) - dd(b))*((dd(b) - dd(c))*dd(b)*dd(c))**2
+         cc(4, a) = -(dd(a) - dd(b))*(dd(c) - dd(a))*((dd(b) - dd(c))*dd(b)*dd(c))**2
+         bb(a) = cc(4, a)*dd(a)
+         ff = ff*(1.0_dp + dd(a))/(dd(a)*(dd(a) - dd(b)))**2
+      enddo
+      bb(4) = -dd(1)*dd(2)*dd(3)*((dd(1) - dd(2))*(dd(2) - dd(3))*(dd(3) - dd(1)))**2
+      ff = -ff/(D(4) + hw)
+      !
+      do i = 1, 4
+         wR0(i) = (cc(i, 1)*ll(1) + cc(i, 2)*ll(2) + cc(i, 3)*ll(3) + bb(i))
+      enddo
+      !
+      wR0 = wR0 * ff
+   END FUNCTION
+
+   FUNCTION delta_vertices(ef, e) result(wI0)
+      !
+      real(dp), INTENT(IN) :: ef
+      real(dp), INTENT(IN) :: e(4)
+      !
+      real(dp) :: wI0(4)
+      !
+      real(dp) :: C, a(4,4)
+      !
+      integer :: i, ii
+      !
+      !
+      !
+      IF(ef > e(4) .or. ef < e(1)) THEN
+         wI0 = 0.0_dp
+         RETURN
+      ENDIF
+      !
+      DO ii = 1, 4
+         DO i = 1, 4
+            IF ( ABS(e(i)-e(ii)) < 1.d-12 ) THEN
+               a(ii,i) = 0.0_dp
+            ELSE
+               a(ii,i) = ( ef - e(i) ) / (e(ii) - e(i) )
+            END IF
+         ENDDO
+      ENDDO
+      !
+      IF( e(1) < ef .AND. ef < e(2) ) THEN
+         !
+         C = a(2,1) * a(3,1) * a(4,1) / (ef - e(1))
+         wI0(1) = a(1,2) + a(1,3) + a(1,4)
+         wI0(2:4) = a(2:4,1)
+
+         wI0 = wI0 * C
+         !
+      ELSEIF( e(2) <= ef .AND. ef < e(3)) THEN
+         !
+         C = a(2,3) * a(3,1) + a(3,2) * a(2,4)
+         !
+         wI0(1) = a(1,4) * C + a(1,3) * a(3,1) * a(2,3)
+         wI0(2) = a(2,3) * C + a(2,4)**2 * a(3,2)
+         wI0(3) = a(3,2) * C + a(3,1)**2 * a(2,3)
+         wI0(4) = a(4,1) * C + a(4,2) * a(2,4) * a(3,2)
+
+         wI0 = wI0 / (e(4) - e(1))
+         !
+      ELSEIF ( e(3) <= ef .AND. ef < e(4)) THEN
+         !
+         C = a(1,4) * a(2,4) * a(3,4) / (e(4) - ef)
+         !
+         wI0(1:3) = a(1:3,4)
+         wI0(4) = a(4,1) + a(4,2) + a(4,3)
+         !
+         wI0 = wI0 * C
+         !
+      ENDIF
+   END FUNCTION
+   !
+   !
+   !
+   FUNCTION tetra_weights_green(ef) RESULT(wg)
+      USE constants, ONLY : pi
+      !-----------------------------------------------------------------------------------
+      !! Calculate weights for an integral of the kind int(Ak delta(ef-ek))
+      !! The resulting wg can be used as sum(Ak * wk)
+      !-----------------------------------------------------------------------------------
+      COMPLEX(DP) :: wg(nbnd, nqs)
+      !! COMPLEX Integration weight of each k
+      REAL(DP), INTENT(IN) :: ef
+      !! The Fermi energy
+      !
+      ! ... local variables
+      !
+      real(dp) :: D(4)
+      !! end wannier90 tetra
+
+      REAL(DP) :: wI(nbnd,nqs), wR(nbnd, nqs)
+
+      INTEGER :: ik, nt, ibnd, ii
+      REAL(DP) :: e(4), wI0(4), wR0(4)
+
+      ! for real part calc
+      ! REAL(DP) :: wR0(4), ef_e(4), log_ef_e(4), prod_a(4), sum_a(4), second_term(4)
+      ! INTEGER :: i3, j3
+      !
+      wg = 0._dp
+      wI = 0._dp
+      wR = 0._dp
+      !
+      DO nt = 1+my_id, ntetra, num_procs
+         !
+         DO ibnd = 1, nbnd
+            !
+            e = ek_sort(:,ibnd,nt)
+            wI0 = delta_vertices(ef, e)
+            !
+            D = -e
+            CALL rm_degen_vertices(ef, D)
+            wR0 = real_vertices(ef, D)
+            !
+            !
+            DO ii = 1, nntetra
+               !
+               ik = tetra(ii, nt)
+               ! IF(opt_flag) THEN
+               wI(ibnd,ik) = wI(ibnd,ik) + DOT_PRODUCT(wlsm(itetra(:,ibnd,nt),ii), wI0(1:4))
+               wR(ibnd,ik) = wR(ibnd,ik) + DOT_PRODUCT(wlsm(itetra(:,ibnd,nt),ii), WR0(1:4))
+               ! ELSE
+               !   ik_s = tetra(itetra(ii,ibnd,nt), nt)
+               !   wI(ibnd,ik_s) = wI(ibnd,ik_s) + wI0(ii)
+               !   wR(ibnd,ik_s) = wR(ibnd,ik_s) + wR0(ii)
+               ! ENDIF
+            ENDDO
+            !
+         ENDDO ! ibnd
+         !
+      ENDDO ! nt
+      ! wg = wg / REAL(ntetra, dp)
+      wg = CMPLX(wR, -pi*wI, kind=DP) / (6.0_dp * nqs)
+      !
+      ! I LEFT OUT THE PART OF AVERAGING OF DEGENERACIES
+      CALL mpi_bsum(nbnd, nqs, wg)
+   END FUNCTION
+
+   ! subroutine sort(list)
+   !   !! Swap sort list of reals
+
+   !   real(DP), intent(inout) :: list(:)
+   !   real(DP) :: aux, tmp
+   !   integer :: i, j, n
+
+   !   n = size(list)
+
+   !   do i = 1, n
+   !     aux = list(i)
+   !     do j = i + 1, n
+   !       if (aux > list(j)) then
+   !         tmp = list(j)
+   !         list(j) = aux
+   !         list(i) = tmp
+   !         aux = tmp
+   !       end if
+   !     end do
+   !   end do
+   ! end subroutine sort
+   !
+   !--------------------------------------------------------------------
+   SUBROUTINE deallocate_tetra( )
+      !--------------------------------------------------------
+      !! Deallocate tetra and wlsm
+      !
+      ntetra = 0
+      nntetra = 0
+      nqs = 0
+      nbnd = 0
+      IF (ALLOCATED(tetra  )) DEALLOCATE (tetra  )
+      IF (ALLOCATED(wlsm   )) DEALLOCATE (wlsm   )
+      IF (ALLOCATED(ek_sort)) DEALLOCATE (ek_sort)
+      IF (ALLOCATED(itetra )) DEALLOCATE (itetra )
+      !
+   END SUBROUTINE deallocate_tetra
+   !
+   !
+   ! FUNCTION tetra_weights_theta( nks, nbnd, et, ef) RESULT(wg)
+   !   !--------------------------------------------------------------------
+   !   !! Calculates weights with the tetrahedron method (P.E.Bloechl).
+   !   !! Fermi energy has to be calculated in previous step.
+   !   !! Generalization to noncollinear case courtesy of Iurii Timrov.
+   !   !! @Note (P. Delugas 8/10/2019) Needs to be called only after initializations,
+   !   !!       stops the program with an error call otherwise.
+   !   !!
+   !   !
+   !   USE kinds
+   !   !
+   !   IMPLICIT NONE
+   !   !
+   !   INTEGER, INTENT(IN) :: nks
+   !   !! Total # of k in irreducible BZ
+   !   INTEGER, INTENT(IN) :: nbnd
+   !   !! number of bands
+   !   REAL(DP), INTENT(IN) :: et(nbnd,nks)
+   !   !! eigenvalues of the hamiltonian
+   !   REAL(DP) :: wg(nbnd,nks)
+   !   !! the weight of each k point and band
+   !   ! wg must be (inout) and not (out) because if is/=0 only terms for
+   !   ! spin=is are initialized; the remaining terms should be kept, not lost.
+   !   REAL(DP), INTENT(IN) :: ef
+   !   !! Fermi energy
+
+   !   ! ... local variables
+   !   !
+   !   REAL(DP) :: e1, e2, e3, e4, c1, c2, c3, c4, etetra(4), dosef
+   !   INTEGER :: ibnd, nt, nk, i, kp1, kp2, kp3, kp4, itetra(4)
+   !   !
+   !   nk = 0
+   !   wg = 0._dp
+   !   !
+   !   DO nt = 1, ntetra
+   !     DO ibnd = 1, nbnd
+   !       !
+   !       ! etetra are the energies at the vertexes of the nt-th tetrahedron
+   !       !
+   !       DO i = 1, 4
+   !         etetra(i) = et (ibnd, tetra(i,nt) + nk)
+   !       ENDDO
+   !       itetra (1) = 0
+   !       CALL hpsort( 4, etetra, itetra )
+   !       !
+   !       ! ...sort in ascending order: e1 < e2 < e3 < e4
+   !       !
+   !       e1 = etetra(1)
+   !       e2 = etetra(2)
+   !       e3 = etetra(3)
+   !       e4 = etetra(4)
+   !       !
+   !       ! kp1-kp4 are the irreducible k-points corresponding to e1-e4
+   !       !
+   !       kp1 = tetra(itetra(1), nt) + nk
+   !       kp2 = tetra(itetra(2), nt) + nk
+   !       kp3 = tetra(itetra(3), nt) + nk
+   !       kp4 = tetra(itetra(4), nt) + nk
+   !       !
+   !       ! calculate weights wg
+   !       !
+   !       IF (ef>=e4) THEN
+   !         !
+   !         wg(ibnd, kp1) = wg(ibnd, kp1) + 0.25d0 / ntetra
+   !         wg(ibnd, kp2) = wg(ibnd, kp2) + 0.25d0 / ntetra
+   !         wg(ibnd, kp3) = wg(ibnd, kp3) + 0.25d0 / ntetra
+   !         wg(ibnd, kp4) = wg(ibnd, kp4) + 0.25d0 / ntetra
+   !         !
+   !       ELSEIF (ef<e4 .AND. ef>=e3) THEN
+   !         !
+   !         c4 = 0.25d0 / ntetra * (e4 - ef)**3 / (e4 - e1) / (e4 - e2) &
+   !           / (e4 - e3)
+   !         dosef = 3.d0 / ntetra * (e4 - ef)**2 / (e4 - e1) / (e4 - e2) &
+   !           / (e4 - e3)
+   !         wg(ibnd,kp1) = wg(ibnd,kp1) + 0.25d0 / ntetra - c4 * &
+   !           (e4 - ef) / (e4 - e1) + dosef * (e1 + e2 + e3 + e4 - 4.d0 * et &
+   !           (ibnd, kp1) ) / 40.d0
+   !         wg(ibnd,kp2) = wg(ibnd,kp2) + 0.25d0 / ntetra - c4 * &
+   !           (e4 - ef) / (e4 - e2) + dosef * (e1 + e2 + e3 + e4 - 4.d0 * et &
+   !           (ibnd, kp2) ) / 40.d0
+   !         wg(ibnd,kp3) = wg(ibnd,kp3) + 0.25d0 / ntetra - c4 * &
+   !           (e4 - ef) / (e4 - e3) + dosef * (e1 + e2 + e3 + e4 - 4.d0 * et &
+   !           (ibnd, kp3) ) / 40.d0
+   !         wg(ibnd,kp4) = wg(ibnd,kp4) + 0.25d0 / ntetra - c4 * &
+   !           (4.d0 - (e4 - ef) * (1.d0 / (e4 - e1) + 1.d0 / (e4 - e2) &
+   !           + 1.d0 / (e4 - e3) ) ) + dosef * (e1 + e2 + e3 + e4 - 4.d0 * &
+   !           et(ibnd,kp4) ) / 40.d0
+   !         !
+   !       ELSEIF (ef<e3 .AND. ef>=e2) THEN
+   !         !
+   !         c1 = 0.25d0 / ntetra * (ef - e1) **2 / (e4 - e1) / (e3 - e1)
+   !         c2 = 0.25d0 / ntetra * (ef - e1) * (ef - e2) * (e3 - ef) &
+   !           / (e4 - e1) / (e3 - e2) / (e3 - e1)
+   !         c3 = 0.25d0 / ntetra * (ef - e2) **2 * (e4 - ef) / (e4 - e2) &
+   !           / (e3 - e2) / (e4 - e1)
+   !         dosef = 1.d0 / ntetra / (e3 - e1) / (e4 - e1) * (3.d0 * &
+   !           (e2 - e1) + 6.d0 * (ef - e2) - 3.d0 * (e3 - e1 + e4 - e2) &
+   !           * (ef - e2) **2 / (e3 - e2) / (e4 - e2) )
+   !         wg(ibnd, kp1) = wg(ibnd, kp1) + c1 + (c1 + c2) * (e3 - ef) &
+   !           / (e3 - e1) + (c1 + c2 + c3) * (e4 - ef) / (e4 - e1) + dosef * &
+   !           (e1 + e2 + e3 + e4 - 4.d0 * et (ibnd, kp1) ) / 40.d0
+   !         wg(ibnd, kp2) = wg(ibnd, kp2) + c1 + c2 + c3 + (c2 + c3) &
+   !           * (e3 - ef) / (e3 - e2) + c3 * (e4 - ef) / (e4 - e2) + dosef * &
+   !           (e1 + e2 + e3 + e4 - 4.d0 * et (ibnd, kp2) ) / 40.d0
+   !         wg(ibnd, kp3) = wg(ibnd, kp3) + (c1 + c2) * (ef - e1) &
+   !           / (e3 - e1) + (c2 + c3) * (ef - e2) / (e3 - e2) + dosef * &
+   !           (e1 + e2 + e3 + e4 - 4.d0 * et (ibnd, kp3) ) / 40.d0
+   !         wg(ibnd, kp4) = wg(ibnd, kp4) + (c1 + c2 + c3) * (ef - e1) &
+   !           / (e4 - e1) + c3 * (ef - e2) / (e4 - e2) + dosef * (e1 + e2 + &
+   !           e3 + e4 - 4.d0 * et (ibnd, kp4) ) / 40.d0
+   !         !
+   !       ELSEIF (ef<e2 .AND. ef>=e1) THEN
+   !         !
+   !         c4 = 0.25d0 / ntetra * (ef - e1) **3 / (e2 - e1) / (e3 - e1) &
+   !           / (e4 - e1)
+   !         dosef = 3.d0 / ntetra * (ef - e1) **2 / (e2 - e1) / (e3 - e1) &
+   !           / (e4 - e1)
+   !         wg(ibnd, kp1) = wg(ibnd, kp1) + c4 * (4.d0 - (ef - e1) &
+   !           * (1.d0 / (e2 - e1) + 1.d0 / (e3 - e1) + 1.d0 / (e4 - e1) ) ) &
+   !           + dosef * (e1 + e2 + e3 + e4 - 4.d0 * et (ibnd, kp1) ) / 40.d0
+   !         wg(ibnd, kp2) = wg(ibnd, kp2) + c4 * (ef - e1) / (e2 - e1) &
+   !           + dosef * (e1 + e2 + e3 + e4 - 4.d0 * et (ibnd, kp2) ) / 40.d0
+   !         wg(ibnd, kp3) = wg(ibnd, kp3) + c4 * (ef - e1) / (e3 - e1) &
+   !           + dosef * (e1 + e2 + e3 + e4 - 4.d0 * et (ibnd, kp3) ) / 40.d0
+   !         wg(ibnd, kp4) = wg(ibnd, kp4) + c4 * (ef - e1) / (e4 - e1) &
+   !           + dosef * (e1 + e2 + e3 + e4 - 4.d0 * et (ibnd, kp4) ) / 40.d0
+
+   !         ! c4 = (ef-e1)**3/(e2-e1)/(e3-e1)/(e4-e1)/4/ntetra
+   !         ! wg(ibnd,kp1) = wg(ibnd,kp1) + (1 + (ef-e2)/(e1-e2) + (ef-e3)/(e1-e3) + (ef-e4)/(e1-e4))*c4
+   !         ! wg(ibnd,kp2) = wg(ibnd,kp2) + (ef-e1)/(e2-e1)*c4
+   !         ! wg(ibnd,kp3) = wg(ibnd,kp3) + (ef-e1)/(e3-e1)*c4
+   !         ! wg(ibnd,kp4) = wg(ibnd,kp4) + (ef-e1)/(e4-e1)*c4
+   !       ENDIF
+   !       !
+   !     ENDDO
+   !   ENDDO
+   !   !
+   ! END FUNCTION tetra_weights_theta
+
+   PURE function tetrahedron_log1p(x)
+      implicit none
+
+      real(dp) :: tetrahedron_log1p
+      real(dp), intent(in) :: x
+      real(dp) :: y, z
+
+      if (ABS(x) > 0.5_dp) then
+         tetrahedron_log1p = LOG(ABS(1.0_dp + x))
+      else
+         y = 1.0_dp + x
+         z = y - 1.0_dp
+         if (z == 0) then
+            tetrahedron_log1p = x
+         else
+            tetrahedron_log1p = x*LOG(y)/z
+         endif
+      endif
+
+   end function tetrahedron_log1p
+
+END MODULE thtetra

--- a/thermal2/timers.f90
+++ b/thermal2/timers.f90
@@ -17,6 +17,8 @@ MODULE timers
   TYPE(nanotimer) :: t_freq =   nanotimer("ph interp & diag"), &
                      t_bose =   nanotimer("bose distrib"), &
                      t_sum  =   nanotimer("sum modes"), &
+                     t_freqd = nanotimer("freqs on grid"), &
+                     t_thtetra = nanotimer("tetrahedra"), &
                      t_fc3int = nanotimer("fc3 interpolate"), &
                      t_fc3dint= nanotimer("fc3 double intp"), &
                      t_fc3m2  = nanotimer("fc3 modulus sq"), &
@@ -85,10 +87,12 @@ MODULE timers
     CALL t_lwcasi%print()
     ioWRITE(stdout,'("   * fine grain terms ")')
     CALL t_freq%print()
+    CALL t_freqd%print()
+    CALL t_thtetra%print()
     CALL t_bose%print()
     CALL t_sum%print()
     CALL t_fc3int%print()
-    CALL t_fc3m2 %print()
+    CALL t_fc3m2%print()
     CALL t_fc3rot%print()
     CALL t_velcty%print()
     CALL t_mpicom%print()


### PR DESCRIPTION
new keys:
- tk: `use_symm` (logicalm default .true.)
- lw, tk: `delta_approx = tetra / gauss` (string, default "tetra")

new features:
- `ip_cart2pat_gemm`, seems way faster with little testing
- single rotation is also available, i found no usage
- `sum_R2` and `sum_R3` for two-step interpolation, only for sparse
- `freq_phq_safe_grad`, finite difference (not tested)
- `fc3%interpolate_grad`, calculated in reciprocal space, for grid and sparse class (not tested)
- type `d3_mixed`, to represent $D(R,q)$
- some helper functions in mpi_thermal

time improvement for `nat3 = 15`:
- 10x faster in interpolation
- 8x faster in rotation
- 10x faster for symmetry
- tetra takes most of CPU time for low nat

What to do:
- code linewidth modifications also for self energy
- better memory management
- sigma in configs is useless if `delta_approx = tetra`
- tetra routine now is the real bottleneck
